### PR TITLE
REALMC-7470 format stack traces for native errors properly

### DIFF
--- a/func.go
+++ b/func.go
@@ -245,9 +245,20 @@ func (f *nativeFuncObject) defaultConstruct(ccall func(ConstructorCall) *Object,
 
 func (f *nativeFuncObject) assertCallable() (func(FunctionCall) Value, bool) {
 	if f.f != nil {
-		return f.f, true
+		return f.Call, true
 	}
 	return nil, false
+}
+
+func (f *nativeFuncObject) Call(call FunctionCall) Value {
+	vm := f.val.runtime.vm
+	prevFuncName := vm.funcName
+	// This is done to display the correct function name in the stack trace when executing a
+	// native function with Function.prototype.apply/call
+	vm.funcName = f.nameProp.get(nil).string()
+	rv := f.f(call)
+	vm.funcName = prevFuncName
+	return rv
 }
 
 func (f *nativeFuncObject) assertConstructor() func(args []Value, newTarget *Object) *Object {

--- a/value.go
+++ b/value.go
@@ -1184,7 +1184,7 @@ func (o *Object) Symbols() []*Symbol {
 // DefineDataProperty is a Go equivalent of Object.defineProperty(o, name, {value: value, writable: writable,
 // configurable: configurable, enumerable: enumerable})
 func (o *Object) DefineDataProperty(name string, value Value, writable, configurable, enumerable Flag) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.defineOwnPropertyStr(unistring.NewFromString(name), PropertyDescriptor{
 			Value:        value,
 			Writable:     writable,
@@ -1197,7 +1197,7 @@ func (o *Object) DefineDataProperty(name string, value Value, writable, configur
 // DefineAccessorProperty is a Go equivalent of Object.defineProperty(o, name, {get: getter, set: setter,
 // configurable: configurable, enumerable: enumerable})
 func (o *Object) DefineAccessorProperty(name string, getter, setter Value, configurable, enumerable Flag) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.defineOwnPropertyStr(unistring.NewFromString(name), PropertyDescriptor{
 			Getter:       getter,
 			Setter:       setter,
@@ -1210,7 +1210,7 @@ func (o *Object) DefineAccessorProperty(name string, getter, setter Value, confi
 // DefineDataPropertySymbol is a Go equivalent of Object.defineProperty(o, name, {value: value, writable: writable,
 // configurable: configurable, enumerable: enumerable})
 func (o *Object) DefineDataPropertySymbol(name *Symbol, value Value, writable, configurable, enumerable Flag) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.defineOwnPropertySym(name, PropertyDescriptor{
 			Value:        value,
 			Writable:     writable,
@@ -1223,7 +1223,7 @@ func (o *Object) DefineDataPropertySymbol(name *Symbol, value Value, writable, c
 // DefineAccessorPropertySymbol is a Go equivalent of Object.defineProperty(o, name, {get: getter, set: setter,
 // configurable: configurable, enumerable: enumerable})
 func (o *Object) DefineAccessorPropertySymbol(name *Symbol, getter, setter Value, configurable, enumerable Flag) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.defineOwnPropertySym(name, PropertyDescriptor{
 			Getter:       getter,
 			Setter:       setter,
@@ -1234,25 +1234,25 @@ func (o *Object) DefineAccessorPropertySymbol(name *Symbol, getter, setter Value
 }
 
 func (o *Object) Set(name string, value interface{}) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.setOwnStr(unistring.NewFromString(name), o.runtime.ToValue(value), true)
 	})
 }
 
 func (o *Object) SetSymbol(name *Symbol, value interface{}) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.setOwnSym(name, o.runtime.ToValue(value), true)
 	})
 }
 
 func (o *Object) Delete(name string) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.deleteStr(unistring.NewFromString(name), true)
 	})
 }
 
 func (o *Object) DeleteSymbol(name *Symbol) error {
-	return tryFunc(func() {
+	return o.runtime.tryFunc(func() {
 		o.self.deleteSym(name, true)
 	})
 }


### PR DESCRIPTION
This change also allows setting an upper limit to the number of stack frames used when formatting an error's stack trace.