### PR TITLE
REALMC-7500 fix regexp lookbehind results and constructor

### DIFF
--- a/builtin_regexp.go
+++ b/builtin_regexp.go
@@ -302,7 +302,7 @@ func (r *Runtime) newRegExp(patternVal, flagsVal Value, proto *Object) *Object {
 	if obj, ok := patternVal.(*Object); ok {
 		if rx, ok := obj.self.(*regexpObject); ok {
 			if flagsVal == nil || flagsVal == _undefined {
-				return rx.clone()
+				return r._newRegExp(rx.source, "", proto)
 			} else {
 				return r._newRegExp(rx.source, flagsVal.toString().String(), proto)
 			}

--- a/regexp.go
+++ b/regexp.go
@@ -2,13 +2,14 @@ package goja
 
 import (
 	"fmt"
-	"github.com/dlclark/regexp2"
-	"github.com/dop251/goja/unistring"
 	"io"
 	"regexp"
 	"sort"
 	"strings"
 	"unicode/utf16"
+
+	"github.com/dlclark/regexp2"
+	"github.com/dop251/goja/unistring"
 )
 
 type regexp2MatchCache struct {
@@ -480,12 +481,10 @@ func (r *regexpObject) execResultToArray(target valueString, result []int) Value
 	captureCount := len(result) >> 1
 	valueArray := make([]Value, captureCount)
 	matchIndex := result[0]
-	lowerBound := matchIndex
 	for index := 0; index < captureCount; index++ {
 		offset := index << 1
-		if result[offset] >= lowerBound {
+		if result[offset] >= 0 {
 			valueArray[index] = target.substring(result[offset], result[offset+1])
-			lowerBound = result[offset]
 		} else {
 			valueArray[index] = _undefined
 		}


### PR DESCRIPTION
- capture the lookbehind expression within the results
- properly support the option to specify a different prototype with Reflect.construct