### PR TITLE
REALMC-7473: Add support for cyclical arrays

### DIFF
--- a/builtin_array.go
+++ b/builtin_array.go
@@ -174,6 +174,8 @@ func (r *Runtime) arrayproto_pop(call FunctionCall) Value {
 func (r *Runtime) arrayproto_join(call FunctionCall) Value {
 	o := call.This.ToObject(r)
 	o.addSeenObject(o)
+	defer o.removeSeenObject(o) // remove when done to allow printing multiple times
+
 	l := int(toLength(o.self.getStr("length", nil)))
 	var sep valueString
 	if s := call.Argument(0); s != _undefined {
@@ -199,8 +201,6 @@ func (r *Runtime) arrayproto_join(call FunctionCall) Value {
 			buf.WriteString(getElementValueString(element.ToObject(r), o))
 		}
 	}
-
-	o.removeSeenObject(o) // remove when done to allow printing multiple times
 
 	return buf.String()
 }

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -206,6 +206,7 @@ func (r *Runtime) arrayproto_join(call FunctionCall) Value {
 		}
 	}
 	buf.WriteString(newStringValue("]"))
+	r.RemoveSeenObject(o) // remove when done printing to allow printing multiple times
 
 	return buf.String()
 }

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -186,8 +186,6 @@ func (r *Runtime) arrayproto_join(call FunctionCall) Value {
 	}
 
 	var buf valueStringBuilder
-	buf.WriteString(newStringValue("["))
-
 	element0 := o.self.getIdx(valueInt(0), nil)
 	if element0 != nil && element0 != _undefined && element0 != _null {
 		buf.WriteString(element0.toString())
@@ -205,7 +203,6 @@ func (r *Runtime) arrayproto_join(call FunctionCall) Value {
 			}
 		}
 	}
-	buf.WriteString(newStringValue("]"))
 	r.RemoveSeenObject(o) // remove when done printing to allow printing multiple times
 
 	return buf.String()

--- a/object.go
+++ b/object.go
@@ -121,6 +121,8 @@ type Object struct {
 
 	mu            sync.RWMutex
 	cyclicalCount int
+
+	seenObjects map[*Object]bool
 }
 
 func (o *Object) CyclicalCount() int {
@@ -138,6 +140,43 @@ func (o *Object) DecCyclicalCount() {
 	defer o.mu.Unlock()
 
 	o.cyclicalCount--
+}
+
+func (o *Object) AddSeenObject(ptr *Object) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.seenObjects == nil {
+		o.seenObjects = make(map[*Object]bool)
+	}
+	if _, ok := o.seenObjects[ptr]; !ok {
+		o.seenObjects[ptr] = true
+	}
+}
+
+func (o *Object) AddSeenObjectMap(seen map[*Object]bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.seenObjects == nil {
+		o.seenObjects = seen
+	} else {
+		for ptr := range seen {
+			o.seenObjects[ptr] = true
+		}
+	}
+}
+
+func (o *Object) RemoveSeenObject(ptr *Object) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.seenObjects == nil {
+		return
+	}
+	if _, ok := o.seenObjects[ptr]; ok {
+		delete(o.seenObjects, ptr)
+	}
 }
 
 type iterNextFunc func() (propIterItem, iterNextFunc)

--- a/object.go
+++ b/object.go
@@ -142,41 +142,37 @@ func (o *Object) DecCyclicalCount() {
 	o.cyclicalCount--
 }
 
-func (o *Object) AddSeenObject(ptr *Object) {
+func (o *Object) addSeenObject(ptr *Object) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
 	if o.seenObjects == nil {
 		o.seenObjects = make(map[*Object]bool)
 	}
-	if _, ok := o.seenObjects[ptr]; !ok {
-		o.seenObjects[ptr] = true
-	}
+	o.seenObjects[ptr] = true
 }
 
-func (o *Object) AddSeenObjectMap(seen map[*Object]bool) {
+func (o *Object) addSeenObjectMap(seen map[*Object]bool) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
 	if o.seenObjects == nil {
 		o.seenObjects = seen
-	} else {
-		for ptr := range seen {
-			o.seenObjects[ptr] = true
-		}
+		return
+	}
+	for ptr := range seen {
+		o.seenObjects[ptr] = true
 	}
 }
 
-func (o *Object) RemoveSeenObject(ptr *Object) {
+func (o *Object) removeSeenObject(ptr *Object) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
 	if o.seenObjects == nil {
 		return
 	}
-	if _, ok := o.seenObjects[ptr]; ok {
-		delete(o.seenObjects, ptr)
-	}
+	delete(o.seenObjects, ptr)
 }
 
 type iterNextFunc func() (propIterItem, iterNextFunc)

--- a/runtime.go
+++ b/runtime.go
@@ -216,13 +216,20 @@ func (self *Runtime) SetStackTraceLimit(limit int) {
 }
 
 func (self *Runtime) AddNewSeenObject(ptr *Object) {
-	seen := self.seenObjects
-	if seen == nil {
-		seen = make(map[*Object]bool)
-		self.seenObjects = seen
+	if self.seenObjects == nil {
+		self.seenObjects = make(map[*Object]bool)
 	}
-	if _, ok := seen[ptr]; !ok {
+	if _, ok := self.seenObjects[ptr]; !ok {
 		self.seenObjects[ptr] = true
+	}
+}
+
+func (self *Runtime) RemoveSeenObject(ptr *Object) {
+	if self.seenObjects == nil {
+		self.seenObjects = make(map[*Object]bool)
+	}
+	if _, ok := self.seenObjects[ptr]; ok {
+		delete(self.seenObjects, ptr)
 	}
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -196,6 +196,8 @@ type Runtime struct {
 
 	Limiter *rate.Limiter
 	ticks   uint64
+
+	seenObjects map[*Object]bool
 }
 
 func (self *Runtime) Ticks() uint64 {
@@ -211,6 +213,17 @@ func (self *Runtime) SetStackDepthLimit(limit int) {
 // is 10. This is consistent with V8 and SpiderMonkey.
 func (self *Runtime) SetStackTraceLimit(limit int) {
 	self.stackTraceLimit = limit
+}
+
+func (self *Runtime) AddNewSeenObject(ptr *Object) {
+	seen := self.seenObjects
+	if seen == nil {
+		seen = make(map[*Object]bool)
+		self.seenObjects = seen
+	}
+	if _, ok := seen[ptr]; !ok {
+		self.seenObjects[ptr] = true
+	}
 }
 
 type StackFrame struct {

--- a/runtime.go
+++ b/runtime.go
@@ -196,8 +196,6 @@ type Runtime struct {
 
 	Limiter *rate.Limiter
 	ticks   uint64
-
-	seenObjects map[*Object]bool
 }
 
 func (self *Runtime) Ticks() uint64 {
@@ -213,24 +211,6 @@ func (self *Runtime) SetStackDepthLimit(limit int) {
 // is 10. This is consistent with V8 and SpiderMonkey.
 func (self *Runtime) SetStackTraceLimit(limit int) {
 	self.stackTraceLimit = limit
-}
-
-func (self *Runtime) AddNewSeenObject(ptr *Object) {
-	if self.seenObjects == nil {
-		self.seenObjects = make(map[*Object]bool)
-	}
-	if _, ok := self.seenObjects[ptr]; !ok {
-		self.seenObjects[ptr] = true
-	}
-}
-
-func (self *Runtime) RemoveSeenObject(ptr *Object) {
-	if self.seenObjects == nil {
-		self.seenObjects = make(map[*Object]bool)
-	}
-	if _, ok := self.seenObjects[ptr]; ok {
-		delete(self.seenObjects, ptr)
-	}
 }
 
 type StackFrame struct {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1766,7 +1766,7 @@ func TestArrayCycleSingle(t *testing.T) {
 	vm := New()
 	prg := MustCompile("test.js", SCRIPT, false)
 	vm.RunProgram(prg)
-	expectedValue := newStringValue("[,,,,,[<Circular Value>],,,,]")
+	expectedValue := newStringValue(",,,,,[<Circular Value>],,,,")
 	if f, ok := AssertFunction(vm.Get("cycle")); ok {
 		v, err := f(nil, nil)
 		if err != nil {
@@ -1797,7 +1797,7 @@ func TestArrayCycleDouble(t *testing.T) {
 	vm := New()
 	prg := MustCompile("test.js", SCRIPT, false)
 	vm.RunProgram(prg)
-	expectedValue := newStringValue("[1,2,3,4,5,[4,5,6,[<Circular Value>]]]")
+	expectedValue := newStringValue("1,2,3,4,5,4,5,6,[<Circular Value>]")
 	if f, ok := AssertFunction(vm.Get("cycle")); ok {
 		v, err := f(nil, nil)
 		if err != nil {
@@ -1829,7 +1829,7 @@ func TestArrayCycleTriple(t *testing.T) {
 	vm := New()
 	prg := MustCompile("test.js", SCRIPT, false)
 	vm.RunProgram(prg)
-	expectedValue := newStringValue("[1,2,[1,2,3,[4,5,6,[<Circular Value>]]],4,5]")
+	expectedValue := newStringValue("1,2,1,2,3,4,5,6,[<Circular Value>],4,5")
 	if f, ok := AssertFunction(vm.Get("cycle")); ok {
 		v, err := f(nil, nil)
 		if err != nil {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1766,8 +1766,8 @@ func TestArrayCycleSingle(t *testing.T) {
 	vm := New()
 	prg := MustCompile("test.js", SCRIPT, false)
 	vm.RunProgram(prg)
-	expectedValue := newStringValue(",,,,,[<Circular Value>],,,,")
-	if f, ok := AssertFunction(vm.Get("cycle")); ok {
+	expectedValue := newStringValue(",,,,,[Circular],,,,")
+	if f, ok := ToFunctionWithContext(vm.Get("cycle")); ok {
 		v, err := f(nil, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -1797,8 +1797,8 @@ func TestArrayCycleDouble(t *testing.T) {
 	vm := New()
 	prg := MustCompile("test.js", SCRIPT, false)
 	vm.RunProgram(prg)
-	expectedValue := newStringValue("1,2,3,4,5,4,5,6,[<Circular Value>]")
-	if f, ok := AssertFunction(vm.Get("cycle")); ok {
+	expectedValue := newStringValue("1,2,3,4,5,4,5,6,[Circular]")
+	if f, ok := ToFunctionWithContext(vm.Get("cycle")); ok {
 		v, err := f(nil, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -1829,8 +1829,8 @@ func TestArrayCycleTriple(t *testing.T) {
 	vm := New()
 	prg := MustCompile("test.js", SCRIPT, false)
 	vm.RunProgram(prg)
-	expectedValue := newStringValue("1,2,1,2,3,4,5,6,[<Circular Value>],4,5")
-	if f, ok := AssertFunction(vm.Get("cycle")); ok {
+	expectedValue := newStringValue("1,2,1,2,3,4,5,6,[Circular],4,5")
+	if f, ok := ToFunctionWithContext(vm.Get("cycle")); ok {
 		v, err := f(nil, nil)
 		if err != nil {
 			t.Fatal(err)

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1755,6 +1755,83 @@ func TestNativeCtorNonNewCall(t *testing.T) {
 	}
 }
 
+func TestArrayCycleSingle(t *testing.T) {
+	const SCRIPT = `
+    function cycle() {
+        var n = new Array(10);
+        n[5] = n;
+        return n.toString();
+    }
+    `
+	vm := New()
+	prg := MustCompile("test.js", SCRIPT, false)
+	vm.RunProgram(prg)
+	expectedValue := newStringValue("[,,,,,[<Circular Value>],,,,]")
+	if f, ok := AssertFunction(vm.Get("cycle")); ok {
+		v, err := f(nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !v.Equals(expectedValue) {
+			t.Fatalf("Unexpected result: %v", v)
+		}
+	}
+}
+
+func TestArrayCycleDouble(t *testing.T) {
+	const SCRIPT = `
+    "use strict";
+    function cycle() {
+		var n = [1,2,3,4,5];
+		var m = [4,5,6];  
+		m.push(n);
+		n.push(m);
+        return n.toString();
+    }
+    `
+	vm := New()
+	prg := MustCompile("test.js", SCRIPT, false)
+	vm.RunProgram(prg)
+	expectedValue := newStringValue("[1,2,3,4,5,[4,5,6,[<Circular Value>]]]")
+	if f, ok := AssertFunction(vm.Get("cycle")); ok {
+		v, err := f(nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !v.Equals(expectedValue) {
+			t.Fatalf("Unexpected result: %v", v)
+		}
+	}
+}
+
+func TestArrayCycleTriple(t *testing.T) {
+	const SCRIPT = `
+    "use strict";
+    function cycle() {
+		var n = [1,2,3,4,5];
+		var m = [1,2,3];  
+		var p = [4,5,6];  
+		p.push(n);  
+		m.push(p); 
+		n[2] = m;  
+		return n.toString();
+    }
+    `
+	vm := New()
+	prg := MustCompile("test.js", SCRIPT, false)
+	vm.RunProgram(prg)
+	expectedValue := newStringValue("[1,2,[1,2,3,[4,5,6,[<Circular Value>]]],4,5]")
+	if f, ok := AssertFunction(vm.Get("cycle")); ok {
+		v, err := f(nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !v.Equals(expectedValue) {
+			t.Fatalf("Unexpected result: %v", v)
+		}
+	}
+}
+
 func ExampleNewSymbol() {
 	sym1 := NewSymbol("66")
 	sym2 := NewSymbol("66")

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1786,6 +1786,11 @@ func TestArrayCycleDouble(t *testing.T) {
 		var m = [4,5,6];  
 		m.push(n);
 		n.push(m);
+
+		// test that multiple calls to toString() does not affect result
+		var tmp0 = n.toString();
+		var tmp1 = m.toString(); 
+
         return n.toString();
     }
     `
@@ -1814,6 +1819,10 @@ func TestArrayCycleTriple(t *testing.T) {
 		p.push(n);  
 		m.push(p); 
 		n[2] = m;  
+
+		// test that multiple calls to toString() does not affect result
+		var tmp0 = m.toString();
+
 		return n.toString();
     }
     `


### PR DESCRIPTION
## [REALMC-7473](https://jira.mongodb.org/browse/REALMC-7473)

If an array ever contained itself in a Javascript function, it would end up creating a Stack Overflow panic when being executed. This was because of a loop found in the array's `toString()` methods where the method was iterating through the array and calling each element's `toString()` method. 

I added a variable to the `Runtime` object that would keep track of the objects seen while iterating through an array. If an object has been seen before, the method will append `[<Circular Value>]` to the string instead of going into a loop. 