### PR TITLE
REALMC-7948: support int64 type 

### DIFF
--- a/compiler_expr.go
+++ b/compiler_expr.go
@@ -1552,8 +1552,10 @@ func (c *compiler) compileNumberLiteral(v *ast.NumberLiteral) compiledExpr {
 	}
 	var val Value
 	switch num := v.Value.(type) {
+	case int:
+		val = intToValue(int64(num))
 	case int64:
-		val = intToValue(num)
+		val = int64ToValue(num)
 	case float64:
 		val = floatToValue(num)
 	default:


### PR DESCRIPTION
I dug around and found that when the an integer arg comes in from js, it will always become a valueInt. this will fix that case and properly delineate between 