### PR TITLE
REALMC-9481: fix charCodeAt not working as expected with special char

### DIFF
--- a/string_ascii.go
+++ b/string_ascii.go
@@ -243,6 +243,11 @@ func (s asciiString) hash(hash *maphash.Hash) uint64 {
 }
 
 func (s asciiString) charAt(idx int) rune {
+	for i, r := range s {
+		if i == idx {
+			return r
+		}
+	}
 	return rune(s[idx])
 }
 


### PR DESCRIPTION
This was a nightmare to discover. Here is the issue:

```js
const db = context.services.get('database').db(context.values.get('DB_NAME'));
const { insertedId } = await db.collection('test').insertOne({ name: 'Übersicht' });
const loadedModel = await db.collection('test').findOne({ _id: insertedId });
 
// These two are different and the second one prints "Ãbersicht"
console.log(new Buffer('Übersicht').toString('utf-8'));
console.log(new Buffer(loadedModel.name).toString('utf-8'))
```