### PR TITLE
REALMC-10239 reduce CPU usage while rate limiting

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -185,8 +185,9 @@ type Runtime struct {
 	stackDepthLimit int
 	stackTraceLimit int
 
-	Limiter *rate.Limiter
-	ticks   uint64
+	limiter          *rate.Limiter
+	limiterTicksLeft int
+	ticks            uint64
 }
 
 func (self *Runtime) Ticks() uint64 {

--- a/vm.go
+++ b/vm.go
@@ -348,7 +348,7 @@ func (vm *vm) run() {
 	interrupted := false
 	ticks := 0
 	for !vm.halt {
-		vm.r.waitOneTick(ticks)
+		vm.r.waitOneTick()
 		if interrupted = atomic.LoadUint32(&vm.interrupted) != 0; interrupted {
 			vm.interruptLock.Lock()
 			interruptFunc, ok := vm.interruptVal.(func())


### PR DESCRIPTION
I've been mostly analyzing the CPU usage with the following function, which came up from this [help ticket](https://jira.mongodb.org/browse/HELP-27429).
```
exports = function(arg){
  const bcrypt = require("bcryptjs");
  return bcrypt.hashSync('bacon', 8);
}
```

With the following changes, we now use less than 1/10 of the CPU time used in master, which means that we can bump up the rate limit in baas. 

### CPU Profile (master)
<img width="766" alt="master cpu top30" src="https://user-images.githubusercontent.com/50110630/133105052-b4a37830-8127-4f04-b072-5ec6e4c91223.png">

![image](https://user-images.githubusercontent.com/50110630/133106041-65feb1e4-2046-4af9-bb89-f2392e3dc7c2.png)


### CPU Profile (patch)
<img width="754" alt="patch cpu top30" src="https://user-images.githubusercontent.com/50110630/133105420-70ab7244-d7ef-4cb5-9887-ce11aa6f1709.png">

### Trace 1 second (master)
<img width="1678" alt="trace master" src="https://user-images.githubusercontent.com/50110630/133109312-64dc2be5-8b05-4eca-8fd2-92330b362c82.png">

### Trace 1 second (patch)
<img width="1578" alt="trace patch" src="https://user-images.githubusercontent.com/50110630/133109330-ad283738-32b1-4577-8437-5e8da93ae816.png">
