### PR TITLE
REALMC-9970: Restore unicode support

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1623,8 +1623,6 @@ func (r *Runtime) ToValue(i interface{}) Value {
 	case Value:
 		return i
 	case string:
-		// for baas purposes, we only need the string representation of the value which is why we force the asciiString type here
-		// the Export / String was obfuscating the return value of BSON hex values
 		return newStringValue(i)
 	case bool:
 		if i {


### PR DESCRIPTION
This seems to resolve the various issued we've been having with unicode strings. We had a comment regarding the reason why we made this change but I had no tests failing with this change both here and in `baas`. See this [evergreen patch](https://spruce.mongodb.com/version/616e1b3d850e6106d027c48c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

## Question 
Since I resumed this work after a longer absence, is there a specific way to test that restoring this doesn't break anything on `baas` ?