### PR TITLE
REALMC-11731: Fix return type for valueInt

### DIFF
--- a/value.go
+++ b/value.go
@@ -45,7 +45,7 @@ var (
 	reflectTypeInt64  = reflect.TypeOf(int64(0))
 	reflectTypeInt32  = reflect.TypeOf(int32(0))
 	reflectTypeUInt32 = reflect.TypeOf(uint32(0))
-	reflectTypeInt    = reflect.TypeOf(int64(0))
+	reflectTypeInt    = reflect.TypeOf(0)
 	reflectTypeBool   = reflect.TypeOf(false)
 	reflectTypeNil    = reflect.TypeOf(nil)
 	reflectTypeFloat  = reflect.TypeOf(float64(0))
@@ -329,7 +329,7 @@ func (i valueInt) Export() interface{} {
 }
 
 func (i valueInt) ExportType() reflect.Type {
-	return reflectTypeInt
+	return reflect.TypeOf(i)
 }
 
 func (i valueInt) hash(*maphash.Hash) uint64 {


### PR DESCRIPTION
This turned out to be a simpler and saner change to satisfy goja test suite and `baas`. Otherwise I'd have to change many of our tests to expect an `int64`.