### PR TITLE
REALMC-11774: support conversion to JS Uint8Array from a Go byte slice

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1784,14 +1784,6 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		obj.self = a
 		a.init()
 		return obj
-	case []uint8:
-		buf := r._newArrayBuffer(r.global.ArrayBufferPrototype, nil)
-		buf.data = i
-		o := &Object{runtime: r}
-		a := r.newUint8ArrayObject(buf, 0, len(buf.data), r.global.Uint8Array)
-		o.self = a
-		a.init()
-		return o
 	}
 
 	origValue := reflect.ValueOf(i)

--- a/runtime.go
+++ b/runtime.go
@@ -1784,6 +1784,14 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		obj.self = a
 		a.init()
 		return obj
+	case []uint8:
+		buf := r._newArrayBuffer(r.global.ArrayBufferPrototype, nil)
+		buf.data = i
+		o := &Object{runtime: r}
+		a := r.newUint8ArrayObject(buf, 0, len(buf.data), r.global.Uint8Array)
+		o.self = a
+		a.init()
+		return o
 	}
 
 	origValue := reflect.ValueOf(i)

--- a/typedarrays.go
+++ b/typedarrays.go
@@ -120,6 +120,14 @@ func (r *Runtime) NewArrayBuffer(data []byte) ArrayBuffer {
 	}
 }
 
+// DIVERSION: NewUint8Array converts a byte slice to a Uint8Array
+// javascript object in order to bypass a Buffer.from call in js-land
+func (r *Runtime) NewUint8Array(data []byte) *typedArrayObject {
+	buf := r._newArrayBuffer(r.global.ArrayBufferPrototype, nil)
+	buf.data = data
+	return r.newUint8ArrayObject(buf, 0, len(buf.data), r.global.Uint8Array)
+}
+
 func (a *uint8Array) get(idx int) Value {
 	return intToValue(int64((*a)[idx]))
 }


### PR DESCRIPTION
_Note: I've added a simple commit for now to get this PR up and running._ 

There are a few approaches we can take here to support this conversion (please let me know if there's a better solution that I've missed). Wanted to get this conversation going and get everyone's thoughts! Some background on why we need this: 

In [`lib_http_parser.go`](https://github.com/10gen/baas/blob/master/function/execution/vm/lib_http_parser.go#L394), we call the [`parserOnBody`](https://github.com/10gen/baas/blob/master/function/execution/common/nodejs_standard_libraries/_http_common.js#L106) function in `_http_common.js`. We end up converting the passed in [`body []byte`](https://github.com/10gen/baas/blob/master/function/execution/vm/lib_http_parser.go#L394) as a [`reflect.Slice`](https://github.com/mongodb-forks/goja/blob/realm/runtime.go#L1823) type in the `ToValue` function in goja within [`CallWithContext`](https://github.com/10gen/baas/blob/master/function/execution/vm/vm_goja.go#L306). This implementation requires us to [add this diversion](https://github.com/10gen/baas/blob/master/function/execution/common/nodejs_standard_libraries/_http_common.js#L114), which is adding 6-8 seconds to our HTTPS (and `axios`) requests (for larger response payloads). 

Converting the `[]byte` that we pass in to `CallWithContext` into a `Uint8Array` object directly from goja instead of using `Buffer.From` reduces the request time of HTTPS from 8-12s to 1-1.5s (5mb payload). 

The brute force solution would be to add a new type to [this switch statement](https://github.com/mongodb-forks/goja/blob/realm/runtime.go#L1665), specifically of type `[]uint8` which the passed in `[]byte` satisfies: 

```
case []uint8:
	buf := r._newArrayBuffer(r.global.ArrayBufferPrototype, nil)
	buf.data = i
	o := &Object{runtime: r}
	a := r.newUint8ArrayObject(buf, 0, len(buf.data), r.global.Uint8Array)
	o.self = a
	a.init()
	return o
```

This can cause issues to other dependencies however. After initial testing, `fs.ReadFileSync` broke since it also passes in `[]byte` to `CallWithContext`. Going down this route may lead to more issues and thus more debugging time on our end with new dependencies. 

Another solution would be to create a `NewUint8ArrayObject` function [here](https://github.com/mongodb-forks/goja/blob/realm/typedarrays.go), and also create a specific `CallWithContextHTTP` (or something along those lines) that adds a type case within its switch statement. 

`goja/typedarrays.go`

```
func (r *Runtime) NewUint8ArrayObject(data []byte) *Object {
	buf := r._newArrayBuffer(r.global.ArrayBufferPrototype, nil)
	buf.data = data
	o := &Object{runtime: r}
	a := r.newUint8ArrayObject(buf, 0, len(buf.data), r.global.Uint8Array)
	o.self = a
	a.init()
	return o
}
```

`function/execution/vm/vm_goja.go`

```
func (g *gojaVM) CallWithContextHTTP(ctx context.Context, this interface{}, f interface{}, args ...interface{}) (funcexecmodels.JSValue, error) {
	...

	convertedArgs := make([]goja.Value, 0, len(args))
	for _, arg := range args {
		var a goja.Value
		switch x := arg.(type) {
		case goja.Value:
			if gObj, ok := x.(*gojaObject); ok {
				a = gObj.Object
			} else {
				a = x
			}
		case jsFunc:
			a = g.vm.ToValue(gojaFunc(x))

                // new switch case
		case []uint8:
			a = g.vm.NewUint8ArrayObject(x)
		
                default:
			a = g.vm.ToValue(x)
		}
		convertedArgs = append(convertedArgs, a)
	}

	return fn(ctx, obj, convertedArgs...)
}
```

While this does solve the issue with slow http requests for now, we seem to bypass the underlying problem of other [performance related issues](https://jira.mongodb.org/browse/REALMC-11795) that we have planned to address [later in this epic](https://docs.google.com/document/d/1e2xm2CxRoYOvhmBSmA4qKlCwJaW2QtolzdpX4He55mI/edit). If the performance related issues solve slow http requests, we can then revert these changes. 