### PR TITLE
REALMC-12488: prevent errors being masked due to lack of captureStackTrace support

### DIFF
--- a/memory_test.go
+++ b/memory_test.go
@@ -351,6 +351,7 @@ func TestMemCheck(t *testing.T) {
 				SizeNumber +
 				SizeEmpty + SizeEmpty, // base object + prototype
 		},
+		// TODO(REALMC-10739) add a test that calls Error.captureStackTrace when it is implemented)
 		{
 			"stash",
 			`checkMem();
@@ -362,6 +363,8 @@ func TestMemCheck(t *testing.T) {
 			`,
 			7 + 3 + // Error "message" field + len("abc")
 				4 + 5 + // Error "name" field + len("Error")
+				5 + // Error "stack" field + len("") since stack is currently always set to an empty string
+				17 + 17 + functionStackOverhead + //  length of the captureStackTrace name + name of associated func and overhead
 				SizeEmpty + SizeEmpty, // base object + prototype
 		},
 		{

--- a/runtime.go
+++ b/runtime.go
@@ -847,6 +847,11 @@ func (r *Runtime) builtin_newBoolean(args []Value, proto *Object) *Object {
 	return r.newPrimitiveObject(v, proto, classBoolean)
 }
 
+// TODO(REALMC-10739) return the actual stack trace
+func (r *Runtime) error_captureStackTrace(call FunctionCall) Value {
+	return newStringValue("")
+}
+
 func (r *Runtime) error_toString(call FunctionCall) Value {
 	var nameStr, msgStr valueString
 	obj := call.This.ToObject(r).self
@@ -880,6 +885,8 @@ func (r *Runtime) builtin_Error(args []Value, proto *Object) *Object {
 	if len(args) > 0 && args[0] != _undefined {
 		obj._putProp("message", args[0], true, true, true)
 	}
+	obj._putProp("captureStackTrace", r.newNativeFunc(r.error_captureStackTrace, nil, "captureStackTrace", nil, 0), true, true, true)
+	obj._putProp("stack", newStringValue(""), true, false, true)
 	obj._putProp("name", proto.Get("name"), true, true, true)
 	return obj.val
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2645,3 +2645,11 @@ func TestExceptionWithinAppliedObjectFunc(t *testing.T) {
 		t.Fatalf("Expected: \n%s\n but got \n%s", expected, ex.String())
 	}
 }
+
+// TODO(REALMC-10739) return the actual stack trace
+func TestErrorCaptureStackTrace(t *testing.T) {
+	const SCRIPT = `
+		new Error("oh no!").captureStackTrace();
+	`
+	testScript1(SCRIPT, newStringValue(""), t)
+}

--- a/vm.go
+++ b/vm.go
@@ -1808,7 +1808,12 @@ func (g getPropCallee) exec(vm *vm) {
 	}
 	prop := obj.self.getStr(n, v)
 	if prop == nil {
-		prop = memberUnresolved{valueUnresolved{r: vm.r, ref: n}}
+		// TODO(REALMC-10739) remove this and ensure the captureStackTrace can be implicitly called from another dependency
+		if g == "captureStackTrace" {
+			prop = vm.r.newNativeFunc(vm.r.error_captureStackTrace, nil, "captureStackTrace", nil, 0)
+		} else {
+			prop = memberUnresolved{valueUnresolved{r: vm.r, ref: n}}
+		}
 	}
 	vm.stack[vm.sp-1] = prop
 


### PR DESCRIPTION
I am fine not merging this PR, but wanted to put out the option if we/users would want visibility into errors while we properly implement Error.captureStackTrace()

This solution is a quick stopgap until [REALMC-10739](https://jira.mongodb.org/browse/REALMC-10739) is implemented. Instead of setting the stack property on the Error and returning a string representation, we just return an empty string. This allows users who are running into their errors being masked by captureStackTrace not being defined can proceed (e.g. the flaky sendgrid test is failing but we cannot see the actual error because we get back `captureStackTrace is not a function`).

The first commit allows us to write a Realm function that calls Error.captureStackTrace explicitly. The second commit is a stopgap to work with Error.captureStackTrace being called implicitly, like in a dependency. It's not great but it seems like both are needed until we figure out the root cause of we cannot recognize the Error [here](https://github.com/mongodb-forks/goja/blob/2d01d5628049e28e65fa8d818b44fb7a25858b25/vm.go#L1813). Unfortunately that would mean that any time the captureStackTrace prop is accessed, we would return that function even if though it is not being called on an Error.

Without this, it's hard to tell why the sendgrid test is actually failing inconsistently