### PR TITLE
REALMC-12488 remove explicit setting of captureStackTrace on Error creation

### DIFF
--- a/memory_test.go
+++ b/memory_test.go
@@ -364,7 +364,6 @@ func TestMemCheck(t *testing.T) {
 			7 + 3 + // Error "message" field + len("abc")
 				4 + 5 + // Error "name" field + len("Error")
 				5 + // Error "stack" field + len("") since stack is currently always set to an empty string
-				17 + 17 + functionStackOverhead + //  length of the captureStackTrace name + name of associated func and overhead
 				SizeEmpty + SizeEmpty, // base object + prototype
 		},
 		{

--- a/runtime.go
+++ b/runtime.go
@@ -885,7 +885,6 @@ func (r *Runtime) builtin_Error(args []Value, proto *Object) *Object {
 	if len(args) > 0 && args[0] != _undefined {
 		obj._putProp("message", args[0], true, true, true)
 	}
-	obj._putProp("captureStackTrace", r.newNativeFunc(r.error_captureStackTrace, nil, "captureStackTrace", nil, 0), true, true, true)
 	obj._putProp("stack", newStringValue(""), true, false, true)
 	obj._putProp("name", proto.Get("name"), true, true, true)
 	return obj.val


### PR DESCRIPTION
removing this means we are fully reliant on checking if captureStackTrace is invoked, and if so returning an empty string regardless if the callee is actually an error, but this keeps us more aligned with actual js Error object