### PR TITLE
BAAS-11318 make int and int64 SameAs return true for equivalent floats

### DIFF
--- a/added_values.go
+++ b/added_values.go
@@ -527,6 +527,9 @@ func (i valueInt64) SameAs(other Value) bool {
 	if otherInt, ok := other.assertInt64(); ok {
 		return int64(i) == otherInt
 	}
+	if f, ok := other.assertFloat(); ok {
+		return float64(i) == f
+	}
 	return false
 }
 

--- a/added_values_test.go
+++ b/added_values_test.go
@@ -21,4 +21,32 @@ func TestInt64SameAsFloat(t *testing.T) {
 	if !valueInt64(5).SameAs(valueFloat(5.0)) {
 		t.Fatal("values are not equal")
 	}
+
+	if !valueInt64(0).SameAs(valueFloat(0.0)) {
+		t.Fatal("values are not equal")
+	}
+
+	if !valueInt64(0).SameAs(valueFloat(-0.0)) {
+		t.Fatal("values are not equal")
+	}
+}
+
+func TestIntStringEquality(t *testing.T) {
+	vm := New()
+
+	res, err := vm.RunString(`"0"==0`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !valueBool(true).Equals(res) {
+		t.Fatal("values are not equal")
+	}
+
+	res, err = vm.RunString(`"0.0"===0`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !valueBool(false).Equals(res) {
+		t.Fatal("values should not be equal")
+	}
 }

--- a/added_values_test.go
+++ b/added_values_test.go
@@ -16,3 +16,9 @@ func TestNumberEquality(t *testing.T) {
 		t.Fatal("values are not equal")
 	}
 }
+
+func TestInt64SameAsFloat(t *testing.T) {
+	if !valueInt64(5).SameAs(valueFloat(5.0)) {
+		t.Fatal("values are not equal")
+	}
+}

--- a/value.go
+++ b/value.go
@@ -285,16 +285,7 @@ func (i valueInt) ToNumber() Value {
 }
 
 func (i valueInt) SameAs(other Value) bool {
-	switch o := other.(type) {
-	case valueInt:
-		return i == o
-	case valueInt64:
-		return i == valueInt(o)
-	case valueFloat:
-		return float64(i) == float64(o)
-	}
-
-	return false
+	return i.StrictEquals(other)
 }
 
 func (i valueInt) Equals(other Value) bool {

--- a/value.go
+++ b/value.go
@@ -285,7 +285,16 @@ func (i valueInt) ToNumber() Value {
 }
 
 func (i valueInt) SameAs(other Value) bool {
-	return i == other
+	switch o := other.(type) {
+	case valueInt:
+		return i == o
+	case valueInt64:
+		return i == valueInt(o)
+	case valueFloat:
+		return float64(i) == float64(o)
+	}
+
+	return false
 }
 
 func (i valueInt) Equals(other Value) bool {

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,35 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestIntSameAsInt(t *testing.T) {
+	if !valueInt(5).SameAs(valueInt(5)) {
+		t.Fatal("values are not equal")
+	}
+}
+
+func TestIntSameAsInt64(t *testing.T) {
+	if !valueInt(5).SameAs(valueInt64(5)) {
+		t.Fatal("values are not equal")
+	}
+}
+
+func TestIntSameAsFloat(t *testing.T) {
+	if !valueInt(5).SameAs(valueFloat(5.0)) {
+		t.Fatal("values are not equal")
+	}
+}
+
+func TestIntZeroSameAsFloatZero(t *testing.T) {
+	if !valueInt(0).SameAs(valueFloat(0.0)) {
+		t.Fatal("values are not equal")
+	}
+	if !valueInt(0).SameAs(valueFloat(-0.0)) {
+		t.Fatal("values are not equal")
+	}
+	if !valueInt(-0).SameAs(valueFloat(-0.0)) {
+		t.Fatal("values are not equal")
+	}
+}

--- a/value_test.go
+++ b/value_test.go
@@ -33,3 +33,30 @@ func TestIntZeroSameAsFloatZero(t *testing.T) {
 		t.Fatal("values are not equal")
 	}
 }
+
+func TestFloatArrayIncludes(t *testing.T) {
+	vm := New()
+	res, err := vm.RunString(`[0.0].includes(0)`)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err.Error())
+	}
+	if !res.SameAs(valueBool(true)) {
+		t.Fatal("value not found in array")
+	}
+
+	res, err = vm.RunString(`[0.0].includes(-0)`)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err.Error())
+	}
+	if !res.SameAs(valueBool(true)) {
+		t.Fatal("value not found in array")
+	}
+
+	res, err = vm.RunString(`[0].includes(0.0)`)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err.Error())
+	}
+	if !res.SameAs(valueBool(true)) {
+		t.Fatal("value not found in array")
+	}
+}

--- a/vm_test.go
+++ b/vm_test.go
@@ -396,6 +396,16 @@ func TestFloatToValue(t *testing.T) {
 			valueFloat(-0),
 		},
 		{
+			2.0000,
+			false,
+			valueFloat(2),
+		},
+		{
+			2.001,
+			false,
+			valueFloat(2.001),
+		},
+		{
 			1.234000,
 			false,
 			valueFloat(1.234),

--- a/vm_test.go
+++ b/vm_test.go
@@ -382,41 +382,32 @@ func TestInt64ToValue(t *testing.T) {
 func TestFloatToValue(t *testing.T) {
 	for _, tc := range []struct {
 		f             float64
-		expectedSign  bool
 		expectedValue Value
 	}{
 		{
 			0.0,
-			false,
 			valueFloat(0),
 		},
 		{
 			-0.0,
-			true,
 			valueFloat(-0),
 		},
 		{
 			2.0000,
-			false,
 			valueFloat(2),
 		},
 		{
 			2.001,
-			false,
 			valueFloat(2.001),
 		},
 		{
 			1.234000,
-			false,
 			valueFloat(1.234),
 		},
 	} {
 		actual := floatToValue(tc.f)
 		if tc.expectedValue != actual {
 			t.Fatalf("%v is not equal to %v", actual, tc.expectedValue)
-		}
-		if tc.expectedSign != math.Signbit(actual.ToFloat()) {
-			t.Fatalf("%v sign bit incorrect", actual)
 		}
 	}
 }

--- a/vm_test.go
+++ b/vm_test.go
@@ -415,5 +415,8 @@ func TestFloatToValue(t *testing.T) {
 		if tc.expectedValue != actual {
 			t.Fatalf("%v is not equal to %v", actual, tc.expectedValue)
 		}
+		if tc.expectedSign != math.Signbit(actual.ToFloat()) {
+			t.Fatalf("%v sign bit incorrect", actual)
+		}
 	}
 }


### PR DESCRIPTION
fixes issue where `[0].includes(0.0)` and `[0.0].includes(0)` return false. Array.includes calls SameAs on the values and not equals so the changes are only needed in SameAs. 

Note: The check is only for Float, Int, and Int64 types. While Equals will return true if the Int is being compared to and identical string or boolean representation, I don't believe we should add that to `SameAs` since those types are different and non-number types