### PR TITLE
BAAS-17382: address mem usage issue for large arrays

### DIFF
--- a/array.go
+++ b/array.go
@@ -534,6 +534,8 @@ func estimateMemUsage(ctx *MemUsageContext, values []Value) (uint64, error) {
 	var averageMemUsage float32
 	sampleSize := len(values) / 10
 
+	// grabbing one sample every "sampleSize" to provide consistent
+	// memory usage across function executions
 	for i := 0; i < len(values); i += sampleSize {
 		if values[i] == nil {
 			continue

--- a/array.go
+++ b/array.go
@@ -521,7 +521,8 @@ func toIdx(v valueInt) uint32 {
 	return math.MaxUint32
 }
 
-var arrayLenThreshold = 1000
+// array length threshold above which we should estimate mem usage
+var arrayLenThreshold = 1_000
 
 // for very large arrays calculating mem usage for each item becomes
 // expensive both in terms of memory used by the host to compute it

--- a/array.go
+++ b/array.go
@@ -521,6 +521,35 @@ func toIdx(v valueInt) uint32 {
 	return math.MaxUint32
 }
 
+var arrayLenThreshold = 1000
+
+// for very large arrays calculating mem usage for each item becomes
+// expensive both in terms of memory used by the host to compute it
+// and timeout. With this function we grab a sample of 10% items
+// determine their average mem usage and use that to estimate mem
+// usage of the whole array
+func estimateMemUsage(ctx *MemUsageContext, values []Value) (uint64, error) {
+	var total, samplesVisited uint64
+	var averageMemUsage float32
+	sampleSize := len(values) / 10
+
+	for i := 0; i < len(values); i += sampleSize {
+		if values[i] == nil {
+			continue
+		}
+
+		inc, err := values[i].MemUsage(ctx)
+		samplesVisited += 1
+		total += inc
+		averageMemUsage = float32(total) / float32(samplesVisited)
+		if err != nil {
+			return uint64(averageMemUsage * float32(len(values))), err
+		}
+	}
+
+	return uint64(averageMemUsage * float32(len(values))), nil
+}
+
 func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 	if a == nil || ctx.IsObjVisited(a) {
 		return SizeEmpty, nil
@@ -536,6 +565,17 @@ func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 
 	if err := ctx.Descend(); err != nil {
 		return total, err
+	}
+
+	if len(a.values) > arrayLenThreshold {
+		inc, err := estimateMemUsage(ctx, a.values)
+		total += inc
+		if err != nil {
+			return total, err
+		}
+
+		ctx.Ascend()
+		return total, nil
 	}
 
 	for _, v := range a.values {


### PR DESCRIPTION
## Why do we need this ?

A customer had a very large array dense with data. When we calculate memory usage of a large array we keep computing until we reach the end of the array.

This would NOT take into account that we could reach the memory limit way before iterating through the whole array. This caused the function to eventually time out and our host memory to spike (and eventually die) since we would continue going with our computation beyond the memory limit.

## Proposals

This PR only demonstrate 1 of a few possible paths forward:

1. Surfacing memory usage at intervals to the poller so that we can interrupt function execution without the need to go through the entire array
2. Check memory usage in goja so that we can stop iterating once we reach the limit
3. Provide an estimate based on samples of values from the array

### Option 1

I haven't explored this as it seemed a more unnatural way to go about it. I'm open to revisit.

### Option 2 (using ctx)

This is a good option with a small footprint. We check the running total against the max allowed, something along these lines:

```go
func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
	if a == nil || ctx.IsObjVisited(a) {
		return SizeEmpty, nil
	}
	ctx.VisitObj(a)

	total := SizeEmpty
	inc, err := a.baseObject.MemUsage(ctx)
	total += inc
	if err != nil {
		return total, err
	}

	if err := ctx.Descend(); err != nil {
		return total, err
	}

	for _, v := range a.values {
		if v == nil {
			continue
		}

		inc, err := v.MemUsage(ctx)
		total += inc
		if err != nil {
			return total, err
		}
                // NEW!
		if total > ctx.MemLimit() {
			return total, nil
		}
	}

	ctx.Ascend()
	return total, nil
}
```

### Option 3 (this PR)

This requires changes in goja and everything else stays the same. A few notes on the approach taken here:
* The threshold is pretty arbitrary for now (we would raise it)
* We could add a ceiling to the number of samples we use to estimate memory usage (e.g. an array with 10 million entries would require us to still go through 1 million values so we could "cap" how many values we go through)
* Sampling seems necessary since JS arrays can have mixed types

## Final notes

I have both implemented so I can switch one approach to the other.

Option 2 is straightforward, it's also more accurate and doesn't affect existing customers (billing). It can't be "tricked" (flip the wcs test from this PR). I wanted to show what option 3 could look like since it was a pretty small lift anyway (and it was the first I drafted). All this to say that option 2 seems like the better way forward which we could use for other `MemUsage` functions (e.g. `*sparseArrayObject`, `*mapObject`, `*Program`, `*baseObject`, `valueStack`).

Obviously if there are additional alternatives I'm open to consider them as well, keeping in mind that we want to get something out soon and we can re-evaluate later on.