### PR TITLE
BAAS-17382: estimate mem usage for large base objects

### DIFF
--- a/array.go
+++ b/array.go
@@ -530,28 +530,28 @@ var arrayLenThreshold = 1_000
 // and timeout. With this function we grab a sample of 10% items
 // determine their average mem usage and use that to estimate mem
 // usage of the whole array
-func estimateMemUsage(ctx *MemUsageContext, values []Value) (uint64, error) {
+func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 	var total, samplesVisited uint64
 	var averageMemUsage float32
-	sampleSize := len(values) / 10
+	sampleSize := len(a.values) / 10
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions
-	for i := 0; i < len(values); i += sampleSize {
-		if values[i] == nil {
+	for i := 0; i < len(a.values); i += sampleSize {
+		if a.values[i] == nil {
 			continue
 		}
 
-		inc, err := values[i].MemUsage(ctx)
+		inc, err := a.values[i].MemUsage(ctx)
 		samplesVisited += 1
 		total += inc
 		averageMemUsage = float32(total) / float32(samplesVisited)
 		if err != nil {
-			return uint64(averageMemUsage * float32(len(values))), err
+			return uint64(averageMemUsage * float32(len(a.values))), err
 		}
 	}
 
-	return uint64(averageMemUsage * float32(len(values))), nil
+	return uint64(averageMemUsage * float32(len(a.values))), nil
 }
 
 func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
@@ -572,7 +572,7 @@ func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 	}
 
 	if len(a.values) > arrayLenThreshold {
-		inc, err := estimateMemUsage(ctx, a.values)
+		inc, err := a.estimateMemUsage(ctx)
 		total += inc
 		if err != nil {
 			return total, err

--- a/memory_test.go
+++ b/memory_test.go
@@ -570,3 +570,79 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 		})
 	}
 }
+
+func TestMemObjectWithPropLenThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		description      string
+		script           string
+		threshold        int
+		expectedSizeDiff uint64
+	}{
+		{
+			"object within threshold",
+			`y = []
+			y.push(null)
+			checkMem()
+			y.push({"a":10, "b":0})
+			checkMem()`,
+			100,
+			SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				(1 + SizeNumber) + // "a" and number
+				(1 + SizeNumber) + // "b" and number
+				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
+		},
+		{
+			"object over threshold",
+			`y = []
+			y.push(null)
+			checkMem()
+			y.push({
+				"a":0, "b":1, "c":2, "d":3, "e":4, "f":5, "g":6, "h":7, "i":8, "j":9,
+				"k":10, "l":11, "m":12, "n":13, "o":14, "p":15, "q":16, "r":17, "s":18, "t":19,
+				"u":20, "v":21, "w":22, "x":23, "y":24, "z":25, "1":26, "2":27, "3":28, "4":29,
+				"5":30, "6":31, "7":32, "8":33, "9":34, "@":35, "#":36, "$":37, "%":38, "^":39,
+				"A":40, "B":41, "C":42, "D":43, "E":44, "F":45, "G":46, "H":47, "I":48, "J":49,
+				"K":50, "L":51, "M":52, "N":53, "O":54, "P":55, "Q":56, "R":57, "S":58, "T":59,
+				"U":60, "V":61, "W":62, "X":63, "Y":64, "Z":65
+			})
+			checkMem()`,
+			60,
+			SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				66*(1+SizeNumber) + // "a" and number
+				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
+		},
+	} {
+		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
+			objPropsLenThreshold = tc.threshold
+			memChecks := []uint64{}
+			vm := New()
+			vm.Set("checkMem", func(call FunctionCall) Value {
+				mem, err := vm.MemUsage(NewMemUsageContext(vm, 100, TestNativeMemUsageChecker{}))
+				if err != nil {
+					t.Fatal(err)
+				}
+				memChecks = append(memChecks, mem)
+				return UndefinedValue()
+			})
+
+			nc := vm.CreateNativeClass("MyNativeVal", func(call FunctionCall) interface{} {
+				return TestNativeValue{}
+			}, nil, nil)
+
+			vm.Set("MyNativeVal", nc.Function)
+
+			_, err := vm.RunString(tc.script)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(memChecks) < 2 {
+				t.Fatalf("expected at least two entries in mem check function, but got %d", len(memChecks))
+			}
+
+			memDiff := memChecks[len(memChecks)-1] - memChecks[0]
+			if memDiff != tc.expectedSizeDiff {
+				t.Fatalf("expected memory change to equal %d but got %d instead", tc.expectedSizeDiff, memDiff)
+			}
+		})
+	}
+}

--- a/object.go
+++ b/object.go
@@ -1648,6 +1648,40 @@ func (ctx *objectExportCtx) putTyped(key objectImpl, typ reflect.Type, value int
 	}
 }
 
+// number of props threshold above which we should estimate mem usage
+var objPropsLenThreshold = 1_000
+
+// for very large objects calculating mem usage for each key/value pair
+// becomes expensive both in terms of memory used by the host to compute it
+// and timeout. With this function we grab a sample of 10% items
+// determine their average mem usage and use that to estimate mem
+// usage of the whole object
+func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
+	var total, samplesVisited uint64
+	var averageMemUsage float32
+	sampleSize := len(o.propNames) / 10
+
+	// grabbing one sample every "sampleSize" to provide consistent
+	// memory usage across function executions
+	for i := 0; i < len(o.propNames); i += sampleSize {
+		k := o.propNames[i]
+		v := o.values[k]
+		if v == nil {
+			continue
+		}
+
+		inc, err := v.MemUsage(ctx)
+		samplesVisited += 1
+		total += inc
+		averageMemUsage = float32(total) / float32(samplesVisited)
+		if err != nil {
+			return uint64(averageMemUsage * float32(len(o.propNames))), err
+		}
+	}
+
+	return uint64(averageMemUsage * float32(len(o.propNames))), nil
+}
+
 func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 	if o == nil || ctx.IsObjVisited(o) {
 		return SizeEmpty, nil
@@ -1659,6 +1693,17 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 	}
 
 	total := SizeEmpty
+
+	if len(o.propNames) > objPropsLenThreshold {
+		inc, err := o.estimateMemUsage(ctx)
+		total += inc
+		if err != nil {
+			return total, err
+		}
+
+		ctx.Ascend()
+		return total, nil
+	}
 
 	for _, k := range o.propNames {
 		v := o.values[k]

--- a/object.go
+++ b/object.go
@@ -1673,6 +1673,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 		inc, err := v.MemUsage(ctx)
 		samplesVisited += 1
 		total += inc
+		total += uint64(len(k))
 		averageMemUsage = float32(total) / float32(samplesVisited)
 		if err != nil {
 			return uint64(averageMemUsage * float32(len(o.propNames))), err
@@ -1700,23 +1701,20 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 		if err != nil {
 			return total, err
 		}
+	} else {
+		for _, k := range o.propNames {
+			v := o.values[k]
+			if v == nil {
+				continue
+			}
 
-		ctx.Ascend()
-		return total, nil
-	}
+			inc, err := v.MemUsage(ctx)
+			total += inc
+			total += uint64(len(k))
 
-	for _, k := range o.propNames {
-		v := o.values[k]
-		if v == nil {
-			continue
-		}
-
-		inc, err := v.MemUsage(ctx)
-		total += inc
-		total += uint64(len(k))
-
-		if err != nil {
-			return total, err
+			if err != nil {
+				return total, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This is in preparation of possible having the base object being the root cause of the memory spike. I can see this happening for an object with a large number of props that don't necessarily have much data in it (you can think of it as the test example I have but with a much higher number of props).