### PR TITLE
BAAS-17702 add mutex to vm funcName to prevent data race

### DIFF
--- a/func.go
+++ b/func.go
@@ -288,12 +288,12 @@ func (f *nativeFuncObject) assertCallable() (func(FunctionCall) Value, bool) {
 
 func (f *nativeFuncObject) Call(call FunctionCall) Value {
 	vm := f.val.runtime.vm
-	prevFuncName := vm.funcName
+	prevFuncName := vm.getFuncName()
 	// This is done to display the correct function name in the stack trace when executing a
 	// native function with Function.prototype.apply/call
-	vm.funcName = f.getStr("name", nil).string()
+	vm.setFuncName(f.getStr("name", nil).string())
 	rv := f.f(call)
-	vm.funcName = prevFuncName
+	vm.setFuncName(prevFuncName)
 	return rv
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -1503,7 +1503,7 @@ func (r *Runtime) RunProgram(p *Program) (result Value, err error) {
 	} else {
 		vm.stack = nil
 		vm.prg = nil
-		vm.funcName = ""
+		vm.setFuncName("")
 		r.leave()
 	}
 	return

--- a/vm.go
+++ b/vm.go
@@ -229,9 +229,9 @@ type instruction interface {
 }
 
 func (vm *vm) getFuncName() unistring.String {
-	vm.funcNameLock.Lock()
+	vm.funcNameLock.RLock()
 	s := vm.funcName
-	vm.funcNameLock.Unlock()
+	vm.funcNameLock.RUnlock()
 	return s
 }
 

--- a/vm.go
+++ b/vm.go
@@ -202,6 +202,7 @@ type vm struct {
 	r            *Runtime
 	prg          *Program
 	funcName     unistring.String // only valid when prg == nil
+	funcNameLock sync.RWMutex
 	pc           int
 	stack        valueStack
 	sp, sb, args int
@@ -225,6 +226,19 @@ type vm struct {
 
 type instruction interface {
 	exec(*vm)
+}
+
+func (vm *vm) getFuncName() unistring.String {
+	vm.funcNameLock.Lock()
+	s := vm.funcName
+	vm.funcNameLock.Unlock()
+	return s
+}
+
+func (vm *vm) setFuncName(s unistring.String) {
+	vm.funcNameLock.Lock()
+	vm.funcName = s
+	vm.funcNameLock.Unlock()
 }
 
 func intToValue(i int64) Value {
@@ -559,7 +573,7 @@ func (vm *vm) captureStack(stack []StackFrame, ctxOffset int) []StackFrame {
 		if vm.prg != nil {
 			funcName = vm.prg.funcName
 		} else {
-			funcName = vm.funcName
+			funcName = vm.getFuncName()
 		}
 		stack = append(stack, StackFrame{prg: vm.prg, pc: vm.pc, funcName: funcName})
 	}
@@ -695,8 +709,8 @@ func (vm *vm) peek() Value {
 func (vm *vm) saveCtx(ctx *vmContext) {
 	ctx.prg, ctx.stash, ctx.newTarget, ctx.result, ctx.pc, ctx.sb, ctx.args =
 		vm.prg, vm.stash, vm.newTarget, vm.result, vm.pc, vm.sb, vm.args
-	if vm.funcName != "" {
-		ctx.funcName = vm.funcName
+	if vm.getFuncName() != "" {
+		ctx.funcName = vm.getFuncName()
 	} else if ctx.prg != nil && ctx.prg.funcName != "" {
 		ctx.funcName = ctx.prg.funcName
 	}
@@ -717,9 +731,11 @@ func (vm *vm) pushCtx() {
 }
 
 func (vm *vm) restoreCtx(ctx *vmContext) {
-	vm.prg, vm.funcName, vm.stash, vm.newTarget, vm.result, vm.pc, vm.sb, vm.args =
-		ctx.prg, ctx.funcName, ctx.stash, ctx.newTarget, ctx.result, ctx.pc, ctx.sb, ctx.args
+	vm.prg, vm.stash, vm.newTarget, vm.result, vm.pc, vm.sb, vm.args =
+		ctx.prg, ctx.stash, ctx.newTarget, ctx.result, ctx.pc, ctx.sb, ctx.args
+
 	vm.ctx = ctx.ctx
+	vm.setFuncName(ctx.funcName)
 }
 
 func (vm *vm) popCtx() {
@@ -2862,7 +2878,7 @@ repeat:
 	case *proxyObject:
 		vm.pushCtx()
 		vm.prg = nil
-		vm.funcName = "proxy"
+		vm.setFuncName("proxy")
 		ret := f.apply(FunctionCall{ctx: vm.ctx, This: vm.stack[vm.sp-n-2], Arguments: vm.stack[vm.sp-n : vm.sp]})
 		if ret == nil {
 			ret = _undefined
@@ -2883,7 +2899,7 @@ func (vm *vm) _nativeCall(f *nativeFuncObject, n int) {
 	if f.f != nil {
 		vm.pushCtx()
 		vm.prg = nil
-		vm.funcName = nilSafe(f.getStr("name", nil)).string()
+		vm.setFuncName(nilSafe(f.getStr("name", nil)).string())
 		ret := f.f(FunctionCall{
 			ctx:       vm.ctx,
 			Arguments: vm.stack[vm.sp-n : vm.sp],


### PR DESCRIPTION
The issue has been present since at least May(it's a bit difficult going further back due to breaking baas changes). This might be caused by reusing the vm in an event loop and can make a ticket if we want to experiment with that route