### PR TITLE
BAAS-18471: Add float integers support in the isSafeInteger native function

### DIFF
--- a/builtin_number.go
+++ b/builtin_number.go
@@ -208,11 +208,11 @@ func (r *Runtime) number_isSafeInteger(call FunctionCall) Value {
 	if arg == _negativeZero {
 		return valueTrue
 	}
-	if i, ok := call.Argument(0).(valueInt64); ok && i >= -(maxInt-1) && i <= maxInt-1 {
+	if i, ok := arg.(valueInt64); ok && i >= -(maxInt-1) && i <= maxInt-1 {
 		return valueTrue
 	}
 	// valueFloat can come in from other nativefuncs like math_abs, this will make sure that the valueFloat is a valid integer
-	if i, ok := call.Argument(0).(valueFloat); ok && i >= -(maxInt-1) && i <= maxInt-1 {
+	if i, ok := arg.(valueFloat); ok && i >= -(maxInt-1) && i <= maxInt-1 {
 		return r.number_isInteger(call)
 	}
 	return valueFalse

--- a/builtin_number.go
+++ b/builtin_number.go
@@ -211,6 +211,10 @@ func (r *Runtime) number_isSafeInteger(call FunctionCall) Value {
 	if i, ok := call.Argument(0).(valueInt64); ok && i >= -(maxInt-1) && i <= maxInt-1 {
 		return valueTrue
 	}
+	// valueFloat can come in from other nativefuncs like math_abs, this will make sure that the valueFloat is a valid integer
+	if i, ok := call.Argument(0).(valueFloat); ok && i >= -(maxInt-1) && i <= maxInt-1 {
+		return r.number_isInteger(call)
+	}
 	return valueFalse
 }
 

--- a/builtin_number_test.go
+++ b/builtin_number_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestIsSafeInteger(t *testing.T) {
 	const SCRIPT = `
 	var maxInt = 9007199254740991
-    var overflowInt = 9007199254740992
-    var maxIntFloat = 9007199254740991.0
+        var overflowInt = 9007199254740992
+        var maxIntFloat = 9007199254740991.0
 	var overflowIntInFloat = 9007199254740992.0
 
 	assert.sameValue(Number.isSafeInteger(1.0), true);

--- a/builtin_number_test.go
+++ b/builtin_number_test.go
@@ -4,10 +4,19 @@ import "testing"
 
 func TestIsSafeInteger(t *testing.T) {
 	const SCRIPT = `
+	var maxInt = 9007199254740991
+    var overflowInt = 9007199254740992
+    var maxIntFloat = 9007199254740991.0
+	var overflowIntInFloat = 9007199254740992.0
+
 	assert.sameValue(Number.isSafeInteger(1.0), true);
 	assert.sameValue(Number.isSafeInteger(1), true);
 	assert.sameValue(Number.isSafeInteger(0), true);
 	assert.sameValue(Number.isSafeInteger(-1), true);
+	assert.sameValue(Number.isSafeInteger(maxInt), true);
+	assert.sameValue(Number.isSafeInteger(maxIntFloat), true);
+	assert.sameValue(Number.isSafeInteger(overflowInt), false);
+	assert.sameValue(Number.isSafeInteger(overflowIntInFloat), false);
 	assert.sameValue(Number.isSafeInteger('1'), false);
 	assert.sameValue(Number.isSafeInteger(1.1), false);
 	`

--- a/builtin_number_test.go
+++ b/builtin_number_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestIsSafeInteger(t *testing.T) {
 	const SCRIPT = `
 	var maxInt = 9007199254740991
-        var overflowInt = 9007199254740992
-        var maxIntFloat = 9007199254740991.0
+	var overflowInt = 9007199254740992
+	var maxIntFloat = 9007199254740991.0
 	var overflowIntInFloat = 9007199254740992.0
 
 	assert.sameValue(Number.isSafeInteger(1.0), true);
@@ -19,6 +19,8 @@ func TestIsSafeInteger(t *testing.T) {
 	assert.sameValue(Number.isSafeInteger(overflowIntInFloat), false);
 	assert.sameValue(Number.isSafeInteger('1'), false);
 	assert.sameValue(Number.isSafeInteger(1.1), false);
+	assert.sameValue(Number.isSafeInteger(Math.abs(1.0)), true);
+	assert.sameValue(Number.isSafeInteger(Math.abs(1.1)), false);
 	`
 	testScript1(TESTLIB+SCRIPT, _undefined, t)
 }

--- a/builtin_number_test.go
+++ b/builtin_number_test.go
@@ -1,0 +1,15 @@
+package goja
+
+import "testing"
+
+func TestIsSafeInteger(t *testing.T) {
+	const SCRIPT = `
+	assert.sameValue(Number.isSafeInteger(1.0), true);
+	assert.sameValue(Number.isSafeInteger(1), true);
+	assert.sameValue(Number.isSafeInteger(0), true);
+	assert.sameValue(Number.isSafeInteger(-1), true);
+	assert.sameValue(Number.isSafeInteger('1'), false);
+	assert.sameValue(Number.isSafeInteger(1.1), false);
+	`
+	testScript1(TESTLIB+SCRIPT, _undefined, t)
+}


### PR DESCRIPTION
[BAAS-18471](https://jira.mongodb.org/browse/BAAS-18471)


The main issue is that the dependency is-odd is setting a value calling math_abs() which returns a float value. The below is the detailed explanation:
1. The is-odd package calls math.abs() which converts string and negative numbers to the positive number.
2. The math.abs() has a native function implementation in goja which always returns valueFloat.
3. Then the isSafeInteger() is called from the is-odd package which leads to the goja problem with the valueFloat

Summary of the change:
Made a change to isSafeInteger to handle a valueFloat since isInteger() already has a case to handle floats ([code link](https://github.com/mongodb-forks/goja/blob/realm/builtin_number.go#L188)). We can add a check if the value coming in isSafeInteger is a valueFloat, to call isInteger() to see if the floatValue is an integer and then check if its within the max int range.

After making this change, the is-odd npm package will correctly work with the math.abs value being passed into isSafeInteger() (as well as all future usage patterns)