### PR TITLE
BAAS-19768: Add constant folding to variable assignments, fix float to int comparisons

### DIFF
--- a/added_values.go
+++ b/added_values.go
@@ -527,10 +527,7 @@ func (i valueInt64) SameAs(other Value) bool {
 	if otherInt, ok := other.assertInt64(); ok {
 		return int64(i) == otherInt
 	}
-	if f, ok := other.assertFloat(); ok {
-		return float64(i) == f
-	}
-	return false
+	return i == other
 }
 
 func (i valueInt64) Equals(other Value) bool {

--- a/added_values_test.go
+++ b/added_values_test.go
@@ -7,7 +7,7 @@ import (
 func TestNumberEquality(t *testing.T) {
 	vm := New()
 
-	res, err := vm.RunString(`var a = new Number('5') 
+	res, err := vm.RunString(`var a = new Number('5')
 	a`)
 	if err != nil {
 		t.Fatal(err)
@@ -17,16 +17,12 @@ func TestNumberEquality(t *testing.T) {
 	}
 }
 
-func TestInt64SameAsFloat(t *testing.T) {
-	if !valueInt64(5).SameAs(valueFloat(5.0)) {
+func TestInt64StrictEqualsFloat(t *testing.T) {
+	if !valueInt64(5).StrictEquals(valueFloat(5.0)) {
 		t.Fatal("values are not equal")
 	}
 
-	if !valueInt64(0).SameAs(valueFloat(0.0)) {
-		t.Fatal("values are not equal")
-	}
-
-	if !valueInt64(0).SameAs(valueFloat(-0.0)) {
+	if !valueInt64(0).StrictEquals(valueFloat(0.0)) {
 		t.Fatal("values are not equal")
 	}
 }

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -597,7 +597,7 @@ func (r *Runtime) arrayproto_includes(call FunctionCall) Value {
 
 	if arr := r.checkStdArrayObj(o); arr != nil {
 		for _, val := range arr.values[n:] {
-			if searchElement.SameAs(val) {
+			if searchElement.StrictEquals(val) {
 				return valueTrue
 			}
 		}
@@ -607,7 +607,7 @@ func (r *Runtime) arrayproto_includes(call FunctionCall) Value {
 	for ; n < length; n++ {
 		idx := valueInt(n)
 		val := nilSafe(o.self.getIdx(idx, nil))
-		if searchElement.SameAs(val) {
+		if searchElement.StrictEquals(val) {
 			return valueTrue
 		}
 	}

--- a/compiler.go
+++ b/compiler.go
@@ -413,10 +413,8 @@ func (p *Program) addSrcMap(srcPos int) {
 func (s *scope) lookupName(name unistring.String) (binding *binding, noDynamics bool) {
 	noDynamics = true
 	toStash := false
-	for curScope := s; curScope != nil; curScope = curScope.outer {
-		if curScope.dynamic {
-			noDynamics = false
-		} else {
+	for curScope := s; ; curScope = curScope.outer {
+		if curScope.outer != nil {
 			if b, exists := curScope.boundNames[name]; exists {
 				if toStash && !b.inStash {
 					b.moveToStash()
@@ -424,6 +422,12 @@ func (s *scope) lookupName(name unistring.String) (binding *binding, noDynamics 
 				binding = b
 				return
 			}
+		} else {
+			noDynamics = false
+			return
+		}
+		if curScope.dynamic {
+			noDynamics = false
 		}
 		if name == "arguments" && curScope.function && !curScope.arrow {
 			curScope.argsNeeded = true
@@ -434,7 +438,6 @@ func (s *scope) lookupName(name unistring.String) (binding *binding, noDynamics 
 			toStash = true
 		}
 	}
-	return
 }
 
 func (s *scope) ensureBoundNamesCreated() {

--- a/compiler_expr.go
+++ b/compiler_expr.go
@@ -2,6 +2,7 @@ package goja
 
 import (
 	"fmt"
+
 	"github.com/dop251/goja/ast"
 	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/token"
@@ -2084,6 +2085,7 @@ func (c *compiler) compileNumberLiteral(v *ast.NumberLiteral) compiledExpr {
 		c.throwSyntaxError(int(v.Idx)-1, "Octal literals are not allowed in strict mode")
 		panic("Unreachable")
 	}
+
 	var val Value
 	switch num := v.Value.(type) {
 	case int:

--- a/compiler_expr.go
+++ b/compiler_expr.go
@@ -395,11 +395,11 @@ func (e *compiledIdentifierExpr) emitGetterAndCallee() {
 func (e *compiledIdentifierExpr) emitVarSetter1(putOnStack bool, emitRight func(isRef bool)) {
 	e.addSrcMap()
 	c := e.c
-	if c.scope.strict {
-		c.checkIdentifierLName(e.name, e.offset)
-	}
 
 	if b, noDynamics := c.scope.lookupName(e.name); noDynamics {
+		if c.scope.strict {
+			c.checkIdentifierLName(e.name, e.offset)
+		}
 		emitRight(false)
 		if b != nil {
 			if putOnStack {
@@ -418,15 +418,7 @@ func (e *compiledIdentifierExpr) emitVarSetter1(putOnStack bool, emitRight func(
 			}
 		}
 	} else {
-		if b != nil {
-			b.emitResolveVar(c.scope.strict)
-		} else {
-			if c.scope.strict {
-				c.emit(resolveVar1Strict(e.name))
-			} else {
-				c.emit(resolveVar1(e.name))
-			}
-		}
+		c.emitVarRef(e.name, e.offset, b)
 		emitRight(true)
 		if putOnStack {
 			c.emit(putValue)
@@ -438,16 +430,15 @@ func (e *compiledIdentifierExpr) emitVarSetter1(putOnStack bool, emitRight func(
 
 func (e *compiledIdentifierExpr) emitVarSetter(valueExpr compiledExpr, putOnStack bool) {
 	e.emitVarSetter1(putOnStack, func(bool) {
-		e.c.emitExpr(valueExpr, true)
+		e.c.emitNamedOrConst(valueExpr, e.name)
 	})
 }
 
-func (c *compiler) emitVarRef(name unistring.String, offset int) {
+func (c *compiler) emitVarRef(name unistring.String, offset int, b *binding) {
 	if c.scope.strict {
 		c.checkIdentifierLName(name, offset)
 	}
 
-	b, _ := c.scope.lookupName(name)
 	if b != nil {
 		b.emitResolveVar(c.scope.strict)
 	} else {
@@ -460,7 +451,8 @@ func (c *compiler) emitVarRef(name unistring.String, offset int) {
 }
 
 func (e *compiledIdentifierExpr) emitRef() {
-	e.c.emitVarRef(e.name, e.offset)
+	b, _ := e.c.scope.lookupName(e.name)
+	e.c.emitVarRef(e.name, e.offset, b)
 }
 
 func (e *compiledIdentifierExpr) emitSetter(valueExpr compiledExpr, putOnStack bool) {
@@ -773,13 +765,6 @@ func (e *deleteGlobalExpr) emitGetter(putOnStack bool) {
 func (e *compiledAssignExpr) emitGetter(putOnStack bool) {
 	switch e.operator {
 	case token.ASSIGN:
-		if fn, ok := e.right.(*compiledFunctionLiteral); ok {
-			if fn.name == nil {
-				if id, ok := e.left.(*compiledIdentifierExpr); ok {
-					fn.lhsName = id.name
-				}
-			}
-		}
 		e.left.emitSetter(e.right, putOnStack)
 	case token.PLUS:
 		e.left.emitUnary(nil, func() {
@@ -1078,14 +1063,14 @@ func (e *compiledFunctionLiteral) emitGetter(putOnStack bool) {
 					}
 				}, item.Initializer, item.Target.Idx0()).emitGetter(true)
 				e.c.emitPattern(pattern, func(target, init compiledExpr) {
-					e.c.emitPatternLexicalAssign(target, init, false)
+					e.c.emitPatternLexicalAssign(target, init)
 				}, false)
 			} else if item.Initializer != nil {
 				markGet := len(e.c.p.code)
 				e.c.emit(nil)
 				mark := len(e.c.p.code)
 				e.c.emit(nil)
-				e.c.compileExpression(item.Initializer).emitGetter(true)
+				e.c.emitExpr(e.c.compileExpression(item.Initializer), true)
 				if firstForwardRef == -1 && (s.isDynamic() || s.bindings[i].useCount() > 0) {
 					firstForwardRef = i
 				}
@@ -1113,7 +1098,7 @@ func (e *compiledFunctionLiteral) emitGetter(putOnStack bool) {
 					e.c.emit(createArgsRestStack(paramsCount))
 				}, rest.Idx0()),
 				func(target, init compiledExpr) {
-					e.c.emitPatternLexicalAssign(target, init, false)
+					e.c.emitPatternLexicalAssign(target, init)
 				})
 		}
 		if firstForwardRef != -1 {
@@ -1484,14 +1469,6 @@ func (c *compiler) emitConst(expr compiledExpr, putOnStack bool) {
 	}
 }
 
-func (c *compiler) emitExpr(expr compiledExpr, putOnStack bool) {
-	if expr.constant() {
-		c.emitConst(expr, putOnStack)
-	} else {
-		expr.emitGetter(putOnStack)
-	}
-}
-
 func (c *compiler) evalConst(expr compiledExpr) (Value, *Exception) {
 	if expr, ok := expr.(*compiledLiteral); ok {
 		return expr.val, nil
@@ -1838,7 +1815,7 @@ func (e *compiledObjectLiteral) emitGetter(putOnStack bool) {
 			}
 			if computed {
 				e.c.emit(_toPropertyKey{})
-				valueExpr.emitGetter(true)
+				e.c.emitExpr(valueExpr, true)
 				switch prop.Kind {
 				case ast.PropertyKindValue, ast.PropertyKindMethod:
 					if anonFn != nil {
@@ -1865,7 +1842,7 @@ func (e *compiledObjectLiteral) emitGetter(putOnStack bool) {
 				if anonFn != nil && !isProto {
 					anonFn.lhsName = key
 				}
-				valueExpr.emitGetter(true)
+				e.c.emitExpr(valueExpr, true)
 				switch prop.Kind {
 				case ast.PropertyKindValue:
 					if isProto {
@@ -1925,7 +1902,7 @@ func (e *compiledArrayLiteral) emitGetter(putOnStack bool) {
 			e.c.emit(pushArraySpread)
 		} else {
 			if v != nil {
-				e.c.compileExpression(v).emitGetter(true)
+				e.c.emitExpr(e.c.compileExpression(v), true)
 			} else {
 				e.c.emit(loadNil)
 			}
@@ -2210,6 +2187,14 @@ func (e *compiledArrayAssignmentPattern) emitGetter(putOnStack bool) {
 	}
 }
 
+func (c *compiler) emitExpr(expr compiledExpr, putOnStack bool) {
+	if expr.constant() {
+		c.emitConst(expr, putOnStack)
+	} else {
+		expr.emitGetter(putOnStack)
+	}
+}
+
 func (c *compiler) emitNamed(expr compiledExpr, name unistring.String) {
 	if en, ok := expr.(interface {
 		emitNamed(name unistring.String)
@@ -2217,6 +2202,14 @@ func (c *compiler) emitNamed(expr compiledExpr, name unistring.String) {
 		en.emitNamed(name)
 	} else {
 		expr.emitGetter(true)
+	}
+}
+
+func (c *compiler) emitNamedOrConst(expr compiledExpr, name unistring.String) {
+	if expr.constant() {
+		c.emitConst(expr, true)
+	} else {
+		c.emitNamed(expr, name)
 	}
 }
 
@@ -2342,7 +2335,7 @@ func (e *compiledPatternInitExpr) emitGetter(putOnStack bool) {
 	if e.def != nil {
 		mark := len(e.c.p.code)
 		e.c.emit(nil)
-		e.def.emitGetter(true)
+		e.c.emitExpr(e.def, true)
 		e.c.p.code[mark] = jdef(len(e.c.p.code) - mark)
 	}
 }
@@ -2352,7 +2345,7 @@ func (e *compiledPatternInitExpr) emitNamed(name unistring.String) {
 	if e.def != nil {
 		mark := len(e.c.p.code)
 		e.c.emit(nil)
-		e.c.emitNamed(e.def, name)
+		e.c.emitNamedOrConst(e.def, name)
 		e.c.p.code[mark] = jdef(len(e.c.p.code) - mark)
 	}
 }

--- a/value.go
+++ b/value.go
@@ -300,7 +300,7 @@ func (i valueInt) ToNumber() Value {
 }
 
 func (i valueInt) SameAs(other Value) bool {
-	return i.StrictEquals(other)
+	return i == other
 }
 
 func (i valueInt) Equals(other Value) bool {

--- a/value_test.go
+++ b/value_test.go
@@ -10,26 +10,20 @@ func TestIntSameAsInt(t *testing.T) {
 	}
 }
 
-func TestIntSameAsInt64(t *testing.T) {
-	if !valueInt(5).SameAs(valueInt64(5)) {
+func TestIntStrictEqualsInt64(t *testing.T) {
+	if !valueInt(5).StrictEquals(valueInt64(5)) {
 		t.Fatal("values are not equal")
 	}
 }
 
-func TestIntSameAsFloat(t *testing.T) {
-	if !valueInt(5).SameAs(valueFloat(5.0)) {
+func TestIntStrictEqualsFloat(t *testing.T) {
+	if !valueInt(5).StrictEquals(valueFloat(5.0)) {
 		t.Fatal("values are not equal")
 	}
 }
 
-func TestIntZeroSameAsFloatZero(t *testing.T) {
-	if !valueInt(0).SameAs(valueFloat(0.0)) {
-		t.Fatal("values are not equal")
-	}
-	if !valueInt(0).SameAs(valueFloat(-0.0)) {
-		t.Fatal("values are not equal")
-	}
-	if !valueInt(-0).SameAs(valueFloat(-0.0)) {
+func TestIntZeroStrictEqualsFloatZero(t *testing.T) {
+	if !valueInt(0).StrictEquals(valueFloat(0.0)) {
 		t.Fatal("values are not equal")
 	}
 }

--- a/vm.go
+++ b/vm.go
@@ -132,7 +132,7 @@ func (r *stashRefLex) set(v Value) {
 }
 
 func (r *stashRefLex) init(v Value) {
-	r.set(v)
+	(*r.v)[r.idx] = v
 }
 
 type stashRefConst struct {
@@ -146,14 +146,11 @@ func (r *stashRefConst) set(v Value) {
 	}
 }
 
-func (r *stashRefConst) init(v Value) {
-	r.set(v)
-}
-
 type objRef struct {
-	base   objectImpl
-	name   unistring.String
-	strict bool
+	base    objectImpl
+	name    unistring.String
+	strict  bool
+	binding bool
 }
 
 func (r *objRef) get() Value {
@@ -161,7 +158,7 @@ func (r *objRef) get() Value {
 }
 
 func (r *objRef) set(v Value) {
-	if r.strict && !r.base.hasOwnPropertyStr(r.name) {
+	if r.strict && r.binding && !r.base.hasOwnPropertyStr(r.name) {
 		panic(referenceError(fmt.Sprintf("%s is not defined", r.name)))
 	}
 	r.base.setOwnStr(r.name, v, r.strict)
@@ -372,9 +369,10 @@ func (s *stash) getRefByName(name unistring.String, strict bool) ref {
 	if obj := s.obj; obj != nil {
 		if stashObjHas(obj, name) {
 			return &objRef{
-				base:   obj.self,
-				name:   name,
-				strict: strict,
+				base:    obj.self,
+				name:    name,
+				strict:  strict,
+				binding: true,
 			}
 		}
 	} else {
@@ -2098,8 +2096,9 @@ func (s resolveVar1) exec(vm *vm) {
 	}
 
 	ref = &objRef{
-		base: vm.r.globalObject.self,
-		name: name,
+		base:    vm.r.globalObject.self,
+		name:    name,
+		binding: true,
 	}
 
 end:
@@ -2178,9 +2177,10 @@ func (s resolveVar1Strict) exec(vm *vm) {
 
 	if vm.r.globalObject.self.hasPropertyStr(name) {
 		ref = &objRef{
-			base:   vm.r.globalObject.self,
-			name:   name,
-			strict: true,
+			base:    vm.r.globalObject.self,
+			name:    name,
+			binding: true,
+			strict:  true,
 		}
 		goto end
 	}

--- a/vm.go
+++ b/vm.go
@@ -247,6 +247,7 @@ func intToValue(i int64) Value {
 	}
 	return valueFloat(i)
 }
+
 func int64ToValue(i int64) Value {
 	if i >= -128 && i <= 127 {
 		return int64Cache[i+128]

--- a/vm_test.go
+++ b/vm_test.go
@@ -65,6 +65,23 @@ func TestEvalVar(t *testing.T) {
 	testScript(SCRIPT, valueTrue, t)
 }
 
+func TestResolveMixedStack1(t *testing.T) {
+	const SCRIPT = `
+	function test(arg) {
+		var a = 1;
+		var scope = {};
+		(function() {return arg})(); // move arguments to stash
+		with (scope) {
+			a++; // resolveMixedStack1 here
+			return a + arg;
+		}
+	}
+	test(40);
+	`
+
+	testScript(SCRIPT, valueInt(42), t)
+}
+
 func BenchmarkVmNOP2(b *testing.B) {
 	prg := []func(*vm){
 		//loadVal(0).exec,

--- a/vm_test.go
+++ b/vm_test.go
@@ -305,10 +305,6 @@ func TestFloatToValue(t *testing.T) {
 			valueFloat(0),
 		},
 		{
-			-0.0,
-			valueFloat(-0),
-		},
-		{
 			2.0000,
 			valueFloat(2),
 		},


### PR DESCRIPTION
The first commit brings in an additional change from goja the second restores the functionality of SameAs that we had to chance for this `[0.0].includes(0)` to return `true`.

## Changes Summary

* Generally a `SameAs` is expected to return `false` when you compare a float to an int/int64. Fort that reason I removed the float assertion.
* Some tests were verifying the behavior of `SameAs` that we introduced to support the `includes` behavior. Those have been updated to use `StrictEquals`.
* In order to maintain the correct functionality of `includes` we now use `StrictEquals` to compare items.
* Test cases where we passed `-0` from go have been removed since they are treated exactly the same as passing `0`

## BAAS

I tested this with some relevant use cases and all seemed good, I have a patch in progress [here](https://spruce.mongodb.com/version/6407926b3e8e860a0d323ef8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
