### PR TITLE
BAAS-20342: udpate goja with changes up to 11/18/22

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -23,7 +23,7 @@ tasks:
             export ROOT_DIR=`pwd`
             export GOROOT=$ROOT_DIR/go
             export PATH=$ROOT_DIR/go/bin:$PATH
-            
+
             cd goja
             go test -v ./...
 
@@ -33,6 +33,6 @@ buildvariants:
     run_on:
       - rhel70
     expansions:
-      go_url: "https://dl.google.com/go/go1.14.10.linux-amd64.tar.gz"
+      go_url: "https://dl.google.com/go/go1.16.10.linux-amd64.tar.gz"
     tasks:
       - name: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.x]
+        go-version: [1.16.x, 1.x]
         os: [ubuntu-latest]
         arch: ["", "386"]
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check formatting
         run: diff -u <(echo -n) <(gofmt -d .)
+        if: ${{ matrix.go-version == '1.x' }}
       - name: Run go vet
         run: go vet ./...
       - name: Run staticcheck

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ performance.
 
 This project was largely inspired by [otto](https://github.com/robertkrimen/otto).
 
-Minimum required Go version is 1.14.
+Minimum required Go version is 1.16.
 
 Features
 --------

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -1141,6 +1141,46 @@ func (r *Runtime) arrayproto_findIndex(call FunctionCall) Value {
 	return intToValue(-1)
 }
 
+func (r *Runtime) arrayproto_findLast(call FunctionCall) Value {
+	o := call.This.ToObject(r)
+	l := toLength(o.self.getStr("length", nil))
+	predicate := r.toCallable(call.Argument(0))
+	fc := FunctionCall{
+		This:      call.Argument(1),
+		Arguments: []Value{nil, nil, o},
+	}
+	for k := int64(l - 1); k >= 0; k-- {
+		idx := valueInt(k)
+		kValue := o.self.getIdx(idx, nil)
+		fc.Arguments[0], fc.Arguments[1] = kValue, idx
+		if predicate(fc).ToBoolean() {
+			return kValue
+		}
+	}
+
+	return _undefined
+}
+
+func (r *Runtime) arrayproto_findLastIndex(call FunctionCall) Value {
+	o := call.This.ToObject(r)
+	l := toLength(o.self.getStr("length", nil))
+	predicate := r.toCallable(call.Argument(0))
+	fc := FunctionCall{
+		This:      call.Argument(1),
+		Arguments: []Value{nil, nil, o},
+	}
+	for k := int64(l - 1); k >= 0; k-- {
+		idx := valueInt(k)
+		kValue := o.self.getIdx(idx, nil)
+		fc.Arguments[0], fc.Arguments[1] = kValue, idx
+		if predicate(fc).ToBoolean() {
+			return idx
+		}
+	}
+
+	return intToValue(-1)
+}
+
 func (r *Runtime) arrayproto_flat(call FunctionCall) Value {
 	o := call.This.ToObject(r)
 	l := toLength(o.self.getStr("length", nil))
@@ -1397,6 +1437,8 @@ func (r *Runtime) createArrayProto(val *Object) objectImpl {
 	o._putProp("filter", r.newNativeFunc(r.arrayproto_filter, nil, "filter", nil, 1), true, false, true)
 	o._putProp("find", r.newNativeFunc(r.arrayproto_find, nil, "find", nil, 1), true, false, true)
 	o._putProp("findIndex", r.newNativeFunc(r.arrayproto_findIndex, nil, "findIndex", nil, 1), true, false, true)
+	o._putProp("findLast", r.newNativeFunc(r.arrayproto_findLast, nil, "findLast", nil, 1), true, false, true)
+	o._putProp("findLastIndex", r.newNativeFunc(r.arrayproto_findLastIndex, nil, "findLastIndex", nil, 1), true, false, true)
 	o._putProp("flat", r.newNativeFunc(r.arrayproto_flat, nil, "flat", nil, 0), true, false, true)
 	o._putProp("flatMap", r.newNativeFunc(r.arrayproto_flatMap, nil, "flatMap", nil, 1), true, false, true)
 	o._putProp("forEach", r.newNativeFunc(r.arrayproto_forEach, nil, "forEach", nil, 1), true, false, true)
@@ -1429,6 +1471,8 @@ func (r *Runtime) createArrayProto(val *Object) objectImpl {
 	bl.setOwnStr("fill", valueTrue, true)
 	bl.setOwnStr("find", valueTrue, true)
 	bl.setOwnStr("findIndex", valueTrue, true)
+	bl.setOwnStr("findLast", valueTrue, true)
+	bl.setOwnStr("findLastIndex", valueTrue, true)
 	bl.setOwnStr("flat", valueTrue, true)
 	bl.setOwnStr("flatMap", valueTrue, true)
 	bl.setOwnStr("includes", valueTrue, true)

--- a/builtin_error.go
+++ b/builtin_error.go
@@ -12,12 +12,11 @@ type errorObject struct {
 
 func (e *errorObject) formatStack() valueString {
 	var b valueStringBuilder
-	if name := e.getStr("name", nil); name != nil {
-		b.WriteString(name.toString())
-		b.WriteRune('\n')
-	} else {
-		b.WriteASCII("Error\n")
+	val := writeErrorString(&b, e.val)
+	if val != nil {
+		b.WriteString(val)
 	}
+	b.WriteRune('\n')
 
 	for _, frame := range e.stack {
 		b.WriteASCII("\tat ")
@@ -141,6 +140,41 @@ func (r *Runtime) builtin_AggregateError(args []Value, proto *Object) *Object {
 	obj._putProp("errors", r.newArrayValues(errors), true, false, true)
 
 	return obj.val
+}
+
+func writeErrorString(sb *valueStringBuilder, obj *Object) valueString {
+	var nameStr, msgStr valueString
+	name := obj.self.getStr("name", nil)
+	if name == nil || name == _undefined {
+		nameStr = asciiString("Error")
+	} else {
+		nameStr = name.toString()
+	}
+	msg := obj.self.getStr("message", nil)
+	if msg == nil || msg == _undefined {
+		msgStr = stringEmpty
+	} else {
+		msgStr = msg.toString()
+	}
+	if nameStr.length() == 0 {
+		return msgStr
+	}
+	if msgStr.length() == 0 {
+		return nameStr
+	}
+	sb.WriteString(nameStr)
+	sb.WriteString(asciiString(": "))
+	sb.WriteString(msgStr)
+	return nil
+}
+
+func (r *Runtime) error_toString(call FunctionCall) Value {
+	var sb valueStringBuilder
+	val := writeErrorString(&sb, r.toObject(call.This))
+	if val != nil {
+		return val
+	}
+	return sb.String()
 }
 
 func (r *Runtime) createErrorPrototype(name valueString) *Object {

--- a/builtin_function.go
+++ b/builtin_function.go
@@ -29,6 +29,10 @@ func (r *Runtime) builtin_Function(args []Value, proto *Object) *Object {
 	return ret
 }
 
+func nativeFuncString(f *nativeFuncObject) Value {
+	return newStringValue(fmt.Sprintf("function %s() { [native code] }", nilSafe(f.getStr("name", nil)).toString()))
+}
+
 func (r *Runtime) functionproto_toString(call FunctionCall) Value {
 	obj := r.toObject(call.This)
 repeat:
@@ -42,9 +46,11 @@ repeat:
 	case *arrowFuncObject:
 		return newStringValue(f.src)
 	case *nativeFuncObject:
-		return newStringValue(fmt.Sprintf("function %s() { [native code] }", nilSafe(f.getStr("name", nil)).toString()))
+		return nativeFuncString(f)
 	case *boundFuncObject:
-		return newStringValue(fmt.Sprintf("function %s() { [native code] }", nilSafe(f.getStr("name", nil)).toString()))
+		return nativeFuncString(&f.nativeFuncObject)
+	case *wrappedFuncObject:
+		return nativeFuncString(&f.nativeFuncObject)
 	case *lazyObject:
 		obj.self = f.create(obj)
 		goto repeat

--- a/builtin_function_test.go
+++ b/builtin_function_test.go
@@ -1,0 +1,14 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestHashbangInFunctionConstructor(t *testing.T) {
+	const SCRIPT = `
+	assert.throws(SyntaxError, function() {
+		new Function("#!")
+	});
+	`
+	testScriptWithTestLib(SCRIPT, _undefined, t)
+}

--- a/builtin_global.go
+++ b/builtin_global.go
@@ -62,7 +62,7 @@ func (r *Runtime) builtin_isFinite(call FunctionCall) Value {
 }
 
 func (r *Runtime) _encode(uriString valueString, unescaped *[256]bool) valueString {
-	reader := uriString.reader(0)
+	reader := uriString.reader()
 	utf8Buf := make([]byte, utf8.UTFMax)
 	needed := false
 	l := 0
@@ -92,7 +92,7 @@ func (r *Runtime) _encode(uriString valueString, unescaped *[256]bool) valueStri
 
 	buf := make([]byte, l)
 	i := 0
-	reader = uriString.reader(0)
+	reader = uriString.reader()
 	for {
 		rn, _, err := reader.ReadRune()
 		if err == io.EOF {
@@ -263,9 +263,10 @@ func (r *Runtime) builtin_escape(call FunctionCall) Value {
 func (r *Runtime) builtin_unescape(call FunctionCall) Value {
 	s := call.Argument(0).toString()
 	l := s.length()
-	_, unicode := s.(unicodeString)
 	var asciiBuf []byte
 	var unicodeBuf []uint16
+	_, u := devirtualizeString(s)
+	unicode := u != nil
 	if unicode {
 		unicodeBuf = make([]uint16, 1, l+1)
 		unicodeBuf[0] = unistring.BOM

--- a/builtin_json.go
+++ b/builtin_json.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/dop251/goja/unistring"
 )
@@ -16,7 +17,7 @@ import (
 const hex = "0123456789abcdef"
 
 func (r *Runtime) builtinJSON_parse(call FunctionCall) Value {
-	d := json.NewDecoder(bytes.NewBufferString(call.Argument(0).toString().String()))
+	d := json.NewDecoder(strings.NewReader(call.Argument(0).toString().String()))
 
 	value, err := r.builtinJSON_decodeValue(d)
 	if err != nil {
@@ -172,11 +173,13 @@ type _builtinJSON_stringifyContext struct {
 	replacerFunction func(FunctionCall) Value
 	gap, indent      string
 	buf              bytes.Buffer
+	allAscii         bool
 }
 
 func (r *Runtime) builtinJSON_stringify(call FunctionCall) Value {
 	ctx := _builtinJSON_stringifyContext{
-		r: r,
+		r:        r,
+		allAscii: true,
 	}
 
 	replacer, _ := call.Argument(1).(*Object)
@@ -258,7 +261,13 @@ func (r *Runtime) builtinJSON_stringify(call FunctionCall) Value {
 	}
 
 	if ctx.do(call.Argument(0)) {
-		return newStringValue(ctx.buf.String())
+		if ctx.allAscii {
+			return asciiString(ctx.buf.String())
+		} else {
+			return &importedString{
+				s: ctx.buf.String(),
+			}
+		}
 	}
 	return _undefined
 }
@@ -312,6 +321,7 @@ func (ctx *_builtinJSON_stringifyContext) str(key Value, holder *Object) bool {
 					panic(err)
 				}
 				ctx.buf.Write(b)
+				ctx.allAscii = false
 				return true
 			} else {
 				switch o1.className() {
@@ -480,7 +490,7 @@ func (ctx *_builtinJSON_stringifyContext) jo(object *Object) {
 
 func (ctx *_builtinJSON_stringifyContext) quote(str valueString) {
 	ctx.buf.WriteByte('"')
-	reader := &lenientUtf16Decoder{utf16Reader: str.utf16Reader(0)}
+	reader := &lenientUtf16Decoder{utf16Reader: str.utf16Reader()}
 	for {
 		r, _, err := reader.ReadRune()
 		if err != nil {
@@ -514,6 +524,9 @@ func (ctx *_builtinJSON_stringifyContext) quote(str valueString) {
 					ctx.buf.WriteByte(hex[r&0xF])
 				} else {
 					ctx.buf.WriteRune(r)
+					if ctx.allAscii && r >= utf8.RuneSelf {
+						ctx.allAscii = false
+					}
 				}
 			}
 		}

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -251,6 +251,10 @@ func (r *Runtime) builtin_newMap(args []Value, newTarget *Object) *Object {
 	if len(args) > 0 {
 		if arg := args[0]; arg != nil && arg != _undefined && arg != _null {
 			adder := mo.getStr("set", nil)
+			adderFn := toMethod(adder)
+			if adderFn == nil {
+				panic(r.NewTypeError("Map.set in missing"))
+			}
 			iter := r.getIterator(arg, nil)
 			i0 := valueInt(0)
 			i1 := valueInt(1)
@@ -262,10 +266,6 @@ func (r *Runtime) builtin_newMap(args []Value, newTarget *Object) *Object {
 					mo.m.set(k, v)
 				})
 			} else {
-				adderFn := toMethod(adder)
-				if adderFn == nil {
-					panic(r.NewTypeError("Map.set in missing"))
-				}
 				iter.iterate(func(item Value) {
 					itemObj := r.toObject(item)
 					k := itemObj.self.getIdx(i0, nil)

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -102,6 +102,44 @@ func TestMapExportToNonNilMap(t *testing.T) {
 	}
 }
 
+func TestMapGetAdderGetIteratorOrder(t *testing.T) {
+	const SCRIPT = `
+	let getterCalled = 0;
+
+	class M extends Map {
+	    get set() {
+	        getterCalled++;
+	        return null;
+	    }
+	}
+
+	let getIteratorCalled = 0;
+
+	let iterable = {};
+	iterable[Symbol.iterator] = () => {
+	    getIteratorCalled++
+	    return {
+	        next: 1
+	    };
+	}
+
+	let thrown = false;
+
+	try {
+	    new M(iterable);
+	} catch (e) {
+	    if (e instanceof TypeError) {
+	        thrown = true;
+	    } else {
+	        throw e;
+	    }
+	}
+
+	thrown && getterCalled === 1 && getIteratorCalled === 0;
+	`
+	testScript(SCRIPT, valueTrue, t)
+}
+
 func ExampleObject_Export_map() {
 	vm := New()
 	m, err := vm.RunString(`

--- a/builtin_reflect.go
+++ b/builtin_reflect.go
@@ -126,6 +126,8 @@ func (r *Runtime) createReflect(val *Object) objectImpl {
 	o._putProp("set", r.newNativeFunc(r.builtin_reflect_set, nil, "set", nil, 3), true, false, true)
 	o._putProp("setPrototypeOf", r.newNativeFunc(r.builtin_reflect_setPrototypeOf, nil, "setPrototypeOf", nil, 2), true, false, true)
 
+	o._putSym(SymToStringTag, valueProp(asciiString("Reflect"), false, false, true))
+
 	return o
 }
 

--- a/builtin_regexp.go
+++ b/builtin_regexp.go
@@ -126,11 +126,14 @@ func convertRegexpToUtf16(patternStr string) string {
 
 // convert any broken UTF-16 surrogate pairs to \uXXXX
 func escapeInvalidUtf16(s valueString) string {
+	if imported, ok := s.(*importedString); ok {
+		return imported.s
+	}
 	if ascii, ok := s.(asciiString); ok {
 		return ascii.String()
 	}
 	var sb strings.Builder
-	rd := &lenientUtf16Decoder{utf16Reader: s.utf16Reader(0)}
+	rd := &lenientUtf16Decoder{utf16Reader: s.utf16Reader()}
 	pos := 0
 	utf8Size := 0
 	var utf8Buf [utf8.UTFMax]byte
@@ -142,7 +145,7 @@ func escapeInvalidUtf16(s valueString) string {
 		if utf16.IsSurrogate(c) {
 			if sb.Len() == 0 {
 				sb.Grow(utf8Size + 7)
-				hrd := s.reader(0)
+				hrd := s.reader()
 				var c rune
 				for p := 0; p < pos; {
 					var size int
@@ -461,7 +464,7 @@ func (r *regexpObject) writeEscapedSource(sb *valueStringBuilder) bool {
 	}
 	pos := 0
 	lastPos := 0
-	rd := &lenientUtf16Decoder{utf16Reader: r.source.utf16Reader(0)}
+	rd := &lenientUtf16Decoder{utf16Reader: r.source.utf16Reader()}
 L:
 	for {
 		c, size, err := rd.ReadRune()

--- a/builtin_set.go
+++ b/builtin_set.go
@@ -209,19 +209,31 @@ func (r *Runtime) builtin_newSet(args []Value, newTarget *Object) *Object {
 	if len(args) > 0 {
 		if arg := args[0]; arg != nil && arg != _undefined && arg != _null {
 			adder := so.getStr("add", nil)
-			iter := r.getIterator(arg, nil)
+			stdArr := r.checkStdArrayIter(arg)
 			if adder == r.global.setAdder {
-				iter.iterate(func(item Value) {
-					so.m.set(item, nil)
-				})
+				if stdArr != nil {
+					for _, v := range stdArr.values {
+						so.m.set(v, nil)
+					}
+				} else {
+					r.getIterator(arg, nil).iterate(func(item Value) {
+						so.m.set(item, nil)
+					})
+				}
 			} else {
 				adderFn := toMethod(adder)
 				if adderFn == nil {
 					panic(r.NewTypeError("Set.add in missing"))
 				}
-				iter.iterate(func(item Value) {
-					adderFn(FunctionCall{ctx: r.vm.ctx, This: o, Arguments: []Value{item}})
-				})
+				if stdArr != nil {
+					for _, item := range stdArr.values {
+						adderFn(FunctionCall{ctx: r.vm.ctx, This: o, Arguments: []Value{item}})
+					}
+				} else {
+					r.getIterator(arg, nil).iterate(func(item Value) {
+						adderFn(FunctionCall{ctx: r.vm.ctx, This: o, Arguments: []Value{item}})
+					})
+				}
 			}
 		}
 	}

--- a/builtin_set_test.go
+++ b/builtin_set_test.go
@@ -140,3 +140,41 @@ func TestSetExportToNonNilMap(t *testing.T) {
 		t.Fatal(m)
 	}
 }
+
+func TestSetGetAdderGetIteratorOrder(t *testing.T) {
+	const SCRIPT = `
+	let getterCalled = 0;
+
+	class S extends Set {
+	    get add() {
+	        getterCalled++;
+	        return null;
+	    }
+	}
+
+	let getIteratorCalled = 0;
+
+	let iterable = {};
+	iterable[Symbol.iterator] = () => {
+	    getIteratorCalled++
+	    return {
+	        next: 1
+	    };
+	}
+
+	let thrown = false;
+
+	try {
+	    new S(iterable);
+	} catch (e) {
+	    if (e instanceof TypeError) {
+	        thrown = true;
+	    } else {
+	        throw e;
+	    }
+	}
+
+	thrown && getterCalled === 1 && getIteratorCalled === 0;
+	`
+	testScript(SCRIPT, valueTrue, t)
+}

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -222,16 +222,27 @@ func (r *Runtime) stringproto_codePointAt(call FunctionCall) Value {
 func (r *Runtime) stringproto_concat(call FunctionCall) Value {
 	r.checkObjectCoercible(call.This)
 	strs := make([]valueString, len(call.Arguments)+1)
-	strs[0] = call.This.toString()
-	_, allAscii := strs[0].(asciiString)
-	totalLen := strs[0].length()
+	a, u := devirtualizeString(call.This.toString())
+	allAscii := true
+	totalLen := 0
+	if u == nil {
+		strs[0] = a
+		totalLen = len(a)
+	} else {
+		strs[0] = u
+		totalLen = u.length()
+		allAscii = false
+	}
 	for i, arg := range call.Arguments {
-		s := arg.toString()
-		if allAscii {
-			_, allAscii = s.(asciiString)
+		a, u := devirtualizeString(arg.toString())
+		if u != nil {
+			allAscii = false
+			totalLen += u.length()
+			strs[i+1] = u
+		} else {
+			totalLen += a.length()
+			strs[i+1] = a
 		}
-		strs[i+1] = s
-		totalLen += s.length()
 	}
 
 	if allAscii {
@@ -451,116 +462,90 @@ func (r *Runtime) stringproto_normalize(call FunctionCall) Value {
 		panic(r.newError(r.global.RangeError, "The normalization form should be one of NFC, NFD, NFKC, NFKD"))
 	}
 
-	if s, ok := s.(unicodeString); ok {
+	switch s := s.(type) {
+	case asciiString:
+		return s
+	case unicodeString:
 		ss := s.String()
 		return newStringValue(f.String(ss))
+	case *importedString:
+		if s.scanned && s.u == nil {
+			return asciiString(s.s)
+		}
+		return newStringValue(f.String(s.s))
+	default:
+		panic(unknownStringTypeErr(s))
+	}
+}
+
+func (r *Runtime) _stringPad(call FunctionCall, start bool) Value {
+	r.checkObjectCoercible(call.This)
+	s := call.This.toString()
+	maxLength := toLength(call.Argument(0))
+	stringLength := int64(s.length())
+	if maxLength <= stringLength {
+		return s
+	}
+	strAscii, strUnicode := devirtualizeString(s)
+	var filler valueString
+	var fillerAscii asciiString
+	var fillerUnicode unicodeString
+	if fillString := call.Argument(1); fillString != _undefined {
+		filler = fillString.toString()
+		if filler.length() == 0 {
+			return s
+		}
+		fillerAscii, fillerUnicode = devirtualizeString(filler)
+	} else {
+		fillerAscii = " "
+		filler = fillerAscii
+	}
+	remaining := toIntStrict(maxLength - stringLength)
+	if fillerUnicode == nil && strUnicode == nil {
+		fl := fillerAscii.length()
+		var sb strings.Builder
+		sb.Grow(toIntStrict(maxLength))
+		if !start {
+			sb.WriteString(string(strAscii))
+		}
+		for remaining >= fl {
+			sb.WriteString(string(fillerAscii))
+			remaining -= fl
+		}
+		if remaining > 0 {
+			sb.WriteString(string(fillerAscii[:remaining]))
+		}
+		if start {
+			sb.WriteString(string(strAscii))
+		}
+		return asciiString(sb.String())
+	}
+	var sb unicodeStringBuilder
+	sb.Grow(toIntStrict(maxLength))
+	if !start {
+		sb.WriteString(s)
+	}
+	fl := filler.length()
+	for remaining >= fl {
+		sb.WriteString(filler)
+		remaining -= fl
+	}
+	if remaining > 0 {
+		sb.WriteString(filler.substring(0, remaining))
+	}
+	if start {
+		sb.WriteString(s)
 	}
 
-	return s
+	return sb.String()
 }
 
 func (r *Runtime) stringproto_padEnd(call FunctionCall) Value {
-	r.checkObjectCoercible(call.This)
-	s := call.This.toString()
-	maxLength := toLength(call.Argument(0))
-	stringLength := int64(s.length())
-	if maxLength <= stringLength {
-		return s
-	}
-	var filler valueString
-	var fillerASCII bool
-	if fillString := call.Argument(1); fillString != _undefined {
-		filler = fillString.toString()
-		if filler.length() == 0 {
-			return s
-		}
-		_, fillerASCII = filler.(asciiString)
-	} else {
-		filler = asciiString(" ")
-		fillerASCII = true
-	}
-	remaining := toIntStrict(maxLength - stringLength)
-	_, stringASCII := s.(asciiString)
-	if fillerASCII && stringASCII {
-		fl := filler.length()
-		var sb strings.Builder
-		sb.Grow(toIntStrict(maxLength))
-		sb.WriteString(s.String())
-		fs := filler.String()
-		for remaining >= fl {
-			sb.WriteString(fs)
-			remaining -= fl
-		}
-		if remaining > 0 {
-			sb.WriteString(fs[:remaining])
-		}
-		return asciiString(sb.String())
-	}
-	var sb unicodeStringBuilder
-	sb.Grow(toIntStrict(maxLength))
-	sb.WriteString(s)
-	fl := filler.length()
-	for remaining >= fl {
-		sb.WriteString(filler)
-		remaining -= fl
-	}
-	if remaining > 0 {
-		sb.WriteString(filler.substring(0, remaining))
-	}
-
-	return sb.String()
+	return r._stringPad(call, false)
 }
 
 func (r *Runtime) stringproto_padStart(call FunctionCall) Value {
-	r.checkObjectCoercible(call.This)
-	s := call.This.toString()
-	maxLength := toLength(call.Argument(0))
-	stringLength := int64(s.length())
-	if maxLength <= stringLength {
-		return s
-	}
-	var filler valueString
-	var fillerASCII bool
-	if fillString := call.Argument(1); fillString != _undefined {
-		filler = fillString.toString()
-		if filler.length() == 0 {
-			return s
-		}
-		_, fillerASCII = filler.(asciiString)
-	} else {
-		filler = asciiString(" ")
-		fillerASCII = true
-	}
-	remaining := toIntStrict(maxLength - stringLength)
-	_, stringASCII := s.(asciiString)
-	if fillerASCII && stringASCII {
-		fl := filler.length()
-		var sb strings.Builder
-		sb.Grow(toIntStrict(maxLength))
-		fs := filler.String()
-		for remaining >= fl {
-			sb.WriteString(fs)
-			remaining -= fl
-		}
-		if remaining > 0 {
-			sb.WriteString(fs[:remaining])
-		}
-		sb.WriteString(s.String())
-		return asciiString(sb.String())
-	}
-	var sb unicodeStringBuilder
-	sb.Grow(toIntStrict(maxLength))
-	fl := filler.length()
-	for remaining >= fl {
-		sb.WriteString(filler)
-		remaining -= fl
-	}
-	if remaining > 0 {
-		sb.WriteString(filler.substring(0, remaining))
-	}
-	sb.WriteString(s)
-
-	return sb.String()
+	return r._stringPad(call, true)
 }
 
 func (r *Runtime) stringproto_repeat(call FunctionCall) Value {
@@ -578,19 +563,20 @@ func (r *Runtime) stringproto_repeat(call FunctionCall) Value {
 		return stringEmpty
 	}
 	num := toIntStrict(numInt)
-	if s, ok := s.(asciiString); ok {
+	a, u := devirtualizeString(s)
+	if u == nil {
 		var sb strings.Builder
-		sb.Grow(len(s) * num)
+		sb.Grow(len(a) * num)
 		for i := 0; i < num; i++ {
-			sb.WriteString(string(s))
+			sb.WriteString(string(a))
 		}
 		return asciiString(sb.String())
 	}
 
 	var sb unicodeStringBuilder
-	sb.Grow(s.length() * num)
+	sb.Grow(u.length() * num)
 	for i := 0; i < num; i++ {
-		sb.WriteString(s)
+		sb.writeUnicodeString(u)
 	}
 	return sb.String()
 }
@@ -611,12 +597,7 @@ func stringReplace(ctx context.Context, s valueString, found [][]int, newstring 
 		return s
 	}
 
-	var str string
-	var isASCII bool
-	if astr, ok := s.(asciiString); ok {
-		str = string(astr)
-		isASCII = true
-	}
+	a, u := devirtualizeString(s)
 
 	var buf valueStringBuilder
 
@@ -632,10 +613,10 @@ func stringReplace(ctx context.Context, s valueString, found [][]int, newstring 
 			for index := 0; index < matchCount; index++ {
 				offset := 2 * index
 				if item[offset] != -1 {
-					if isASCII {
-						argumentList[index] = asciiString(str[item[offset]:item[offset+1]])
+					if u == nil {
+						argumentList[index] = a[item[offset]:item[offset+1]]
 					} else {
-						argumentList[index] = s.substring(item[offset], item[offset+1])
+						argumentList[index] = u.substring(item[offset], item[offset+1])
 					}
 				} else {
 					argumentList[index] = _undefined
@@ -659,10 +640,10 @@ func stringReplace(ctx context.Context, s valueString, found [][]int, newstring 
 			matchCount := len(item) / 2
 			writeSubstitution(s, item[0], matchCount, func(idx int) valueString {
 				if item[idx*2] != -1 {
-					if isASCII {
-						return asciiString(str[item[idx*2]:item[idx*2+1]])
+					if u == nil {
+						return a[item[idx*2]:item[idx*2+1]]
 					}
-					return s.substring(item[idx*2], item[idx*2+1])
+					return u.substring(item[idx*2], item[idx*2+1])
 				}
 				return stringEmpty
 			}, newstring, &buf)

--- a/builtin_string_test.go
+++ b/builtin_string_test.go
@@ -252,4 +252,27 @@ func TestValueStringBuilder(t *testing.T) {
 			t.Fatal(res)
 		}
 	})
+
+	t.Run("concat_ASCII_importedASCII", func(t *testing.T) {
+		t.Parallel()
+		var sb valueStringBuilder
+		sb.WriteString(asciiString("ascii"))
+		sb.WriteString(&importedString{s: " imported_ascii1234567890"})
+		s := sb.String()
+		if res, ok := s.(asciiString); !ok || res != "ascii imported_ascii1234567890" {
+			t.Fatal(s)
+		}
+	})
+
+	t.Run("concat_ASCII_importedUnicode", func(t *testing.T) {
+		t.Parallel()
+		var sb valueStringBuilder
+		sb.WriteString(asciiString("ascii"))
+		sb.WriteString(&importedString{s: " imported_юникод"})
+		s := sb.String()
+		if res, ok := s.(unicodeString); !ok || !res.SameAs(newStringValue("ascii imported_юникод")) {
+			t.Fatal(s)
+		}
+	})
+
 }

--- a/builtin_typedarrays.go
+++ b/builtin_typedarrays.go
@@ -597,6 +597,54 @@ func (r *Runtime) typedArrayProto_findIndex(call FunctionCall) Value {
 	panic(r.NewTypeError("Method TypedArray.prototype.findIndex called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
+func (r *Runtime) typedArrayProto_findLast(call FunctionCall) Value {
+	if ta, ok := r.toObject(call.This).self.(*typedArrayObject); ok {
+		ta.viewedArrayBuf.ensureNotDetached(true)
+		predicate := r.toCallable(call.Argument(0))
+		fc := FunctionCall{
+			This:      call.Argument(1),
+			Arguments: []Value{nil, nil, call.This},
+		}
+		for k := ta.length - 1; k >= 0; k-- {
+			var val Value
+			if ta.isValidIntegerIndex(k) {
+				val = ta.typedArray.get(ta.offset + k)
+			}
+			fc.Arguments[0] = val
+			fc.Arguments[1] = intToValue(int64(k))
+			if predicate(fc).ToBoolean() {
+				return val
+			}
+		}
+		return _undefined
+	}
+	panic(r.NewTypeError("Method TypedArray.prototype.findLast called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+}
+
+func (r *Runtime) typedArrayProto_findLastIndex(call FunctionCall) Value {
+	if ta, ok := r.toObject(call.This).self.(*typedArrayObject); ok {
+		ta.viewedArrayBuf.ensureNotDetached(true)
+		predicate := r.toCallable(call.Argument(0))
+		fc := FunctionCall{
+			This:      call.Argument(1),
+			Arguments: []Value{nil, nil, call.This},
+		}
+		for k := ta.length - 1; k >= 0; k-- {
+			if ta.isValidIntegerIndex(k) {
+				fc.Arguments[0] = ta.typedArray.get(ta.offset + k)
+			} else {
+				fc.Arguments[0] = _undefined
+			}
+			fc.Arguments[1] = intToValue(int64(k))
+			if predicate(fc).ToBoolean() {
+				return fc.Arguments[1]
+			}
+		}
+		return intToValue(-1)
+	}
+	panic(r.NewTypeError("Method TypedArray.prototype.findLastIndex called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+}
+
 func (r *Runtime) typedArrayProto_forEach(call FunctionCall) Value {
 	if ta, ok := r.toObject(call.This).self.(*typedArrayObject); ok {
 		ta.viewedArrayBuf.ensureNotDetached(true)
@@ -1491,6 +1539,8 @@ func (r *Runtime) createTypedArrayProto(val *Object) objectImpl {
 	b._putProp("filter", r.newNativeFunc(r.typedArrayProto_filter, nil, "filter", nil, 1), true, false, true)
 	b._putProp("find", r.newNativeFunc(r.typedArrayProto_find, nil, "find", nil, 1), true, false, true)
 	b._putProp("findIndex", r.newNativeFunc(r.typedArrayProto_findIndex, nil, "findIndex", nil, 1), true, false, true)
+	b._putProp("findLast", r.newNativeFunc(r.typedArrayProto_findLast, nil, "findLast", nil, 1), true, false, true)
+	b._putProp("findLastIndex", r.newNativeFunc(r.typedArrayProto_findLastIndex, nil, "findLastIndex", nil, 1), true, false, true)
 	b._putProp("forEach", r.newNativeFunc(r.typedArrayProto_forEach, nil, "forEach", nil, 1), true, false, true)
 	b._putProp("includes", r.newNativeFunc(r.typedArrayProto_includes, nil, "includes", nil, 1), true, false, true)
 	b._putProp("indexOf", r.newNativeFunc(r.typedArrayProto_indexOf, nil, "indexOf", nil, 1), true, false, true)

--- a/builtin_weakmap.go
+++ b/builtin_weakmap.go
@@ -118,6 +118,10 @@ func (r *Runtime) builtin_newWeakMap(args []Value, newTarget *Object) *Object {
 	if len(args) > 0 {
 		if arg := args[0]; arg != nil && arg != _undefined && arg != _null {
 			adder := wmo.getStr("set", nil)
+			adderFn := toMethod(adder)
+			if adderFn == nil {
+				panic(r.NewTypeError("WeakMap.set in missing"))
+			}
 			iter := r.getIterator(arg, nil)
 			i0 := valueInt(0)
 			i1 := valueInt(1)
@@ -129,10 +133,6 @@ func (r *Runtime) builtin_newWeakMap(args []Value, newTarget *Object) *Object {
 					wmo.m.set(r.toObject(k), v)
 				})
 			} else {
-				adderFn := toMethod(adder)
-				if adderFn == nil {
-					panic(r.NewTypeError("WeakMap.set in missing"))
-				}
 				iter.iterate(func(item Value) {
 					itemObj := r.toObject(item)
 					k := itemObj.self.getIdx(i0, nil)

--- a/builtin_weakmap_test.go
+++ b/builtin_weakmap_test.go
@@ -36,3 +36,41 @@ func TestWeakMap(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWeakMapGetAdderGetIteratorOrder(t *testing.T) {
+	const SCRIPT = `
+	let getterCalled = 0;
+
+	class M extends WeakMap {
+	    get set() {
+	        getterCalled++;
+	        return null;
+	    }
+	}
+
+	let getIteratorCalled = 0;
+
+	let iterable = {};
+	iterable[Symbol.iterator] = () => {
+	    getIteratorCalled++
+	    return {
+	        next: 1
+	    };
+	}
+
+	let thrown = false;
+
+	try {
+	    new M(iterable);
+	} catch (e) {
+	    if (e instanceof TypeError) {
+	        thrown = true;
+	    } else {
+	        throw e;
+	    }
+	}
+
+	thrown && getterCalled === 1 && getIteratorCalled === 0;
+	`
+	testScript(SCRIPT, valueTrue, t)
+}

--- a/builtin_weakset.go
+++ b/builtin_weakset.go
@@ -46,17 +46,6 @@ func (r *Runtime) weakSetProto_has(call FunctionCall) Value {
 	return valueFalse
 }
 
-func (r *Runtime) populateWeakSetGeneric(s *Object, adderValue Value, iterable Value) {
-	adder := toMethod(adderValue)
-	if adder == nil {
-		panic(r.NewTypeError("WeakSet.add is not set"))
-	}
-	iter := r.getIterator(iterable, nil)
-	iter.iterate(func(val Value) {
-		adder(FunctionCall{ctx: r.ctx, This: s, Arguments: []Value{val}})
-	})
-}
-
 func (r *Runtime) builtin_newWeakSet(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
 		panic(r.needNew("WeakSet"))
@@ -74,15 +63,32 @@ func (r *Runtime) builtin_newWeakSet(args []Value, newTarget *Object) *Object {
 	if len(args) > 0 {
 		if arg := args[0]; arg != nil && arg != _undefined && arg != _null {
 			adder := wso.getStr("add", nil)
+			stdArr := r.checkStdArrayIter(arg)
 			if adder == r.global.weakSetAdder {
-				if arr := r.checkStdArrayIter(arg); arr != nil {
-					for _, v := range arr.values {
+				if stdArr != nil {
+					for _, v := range stdArr.values {
 						wso.s.set(r.toObject(v), nil)
 					}
-					return o
+				} else {
+					r.getIterator(arg, nil).iterate(func(item Value) {
+						wso.s.set(r.toObject(item), nil)
+					})
+				}
+			} else {
+				adderFn := toMethod(adder)
+				if adderFn == nil {
+					panic(r.NewTypeError("WeakSet.add in missing"))
+				}
+				if stdArr != nil {
+					for _, item := range stdArr.values {
+						adderFn(FunctionCall{This: o, Arguments: []Value{item}})
+					}
+				} else {
+					r.getIterator(arg, nil).iterate(func(item Value) {
+						adderFn(FunctionCall{This: o, Arguments: []Value{item}})
+					})
 				}
 			}
-			r.populateWeakSetGeneric(o, adder, arg)
 		}
 	}
 	return o

--- a/builtin_weakset_test.go
+++ b/builtin_weakset_test.go
@@ -61,3 +61,41 @@ func TestWeakSetArrayGeneric(t *testing.T) {
 	`
 	testScript(SCRIPT, valueTrue, t)
 }
+
+func TestWeakSetGetAdderGetIteratorOrder(t *testing.T) {
+	const SCRIPT = `
+	let getterCalled = 0;
+
+	class S extends WeakSet {
+	    get add() {
+	        getterCalled++;
+	        return null;
+	    }
+	}
+
+	let getIteratorCalled = 0;
+
+	let iterable = {};
+	iterable[Symbol.iterator] = () => {
+	    getIteratorCalled++
+	    return {
+	        next: 1
+	    };
+	}
+
+	let thrown = false;
+
+	try {
+	    new S(iterable);
+	} catch (e) {
+	    if (e instanceof TypeError) {
+	        thrown = true;
+	    } else {
+	        throw e;
+	    }
+	}
+
+	thrown && getterCalled === 1 && getIteratorCalled === 0;
+	`
+	testScript(SCRIPT, valueTrue, t)
+}

--- a/compiler_stmt.go
+++ b/compiler_stmt.go
@@ -624,11 +624,14 @@ func (c *compiler) emitBlockExitCode(label *ast.Identifier, idx file.Idx, isBrea
 		c.throwSyntaxError(int(idx)-1, "Could not find block")
 		panic("unreachable")
 	}
+	contForLoop := !isBreak && block.typ == blockLoop
 L:
 	for b := c.block; b != block; b = b.outer {
 		switch b.typ {
 		case blockIterScope:
-			if !isBreak && b.outer == block {
+			// blockIterScope in 'for' loops is shared across iterations, so
+			// continue should not pop it.
+			if contForLoop && b.outer == block {
 				break L
 			}
 			fallthrough

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5601,6 +5601,18 @@ func TestForInLoopContinueOuter(t *testing.T) {
 	testScript(SCRIPT, _undefined, t)
 }
 
+func TestLexicalDeclInSwitch(t *testing.T) {
+	const SCRIPT = `
+	switch(0) {
+	    case 1:
+	        if (false) b = 3;
+	    case 2:
+	        const c = 1;
+	}
+	`
+	testScript(SCRIPT, _undefined, t)
+}
+
 /*
 func TestBabel(t *testing.T) {
 	src, err := os.ReadFile("babel7.js")

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1,7 +1,7 @@
 package goja
 
 import (
-	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 )
@@ -5550,7 +5550,7 @@ func TestThisResolutionWithStackVar(t *testing.T) {
 
 /*
 func TestBabel(t *testing.T) {
-	src, err := ioutil.ReadFile("babel7.js")
+	src, err := os.ReadFile("babel7.js")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5566,7 +5566,7 @@ func TestBabel(t *testing.T) {
 }*/
 
 func BenchmarkCompile(b *testing.B) {
-	data, err := ioutil.ReadFile("testdata/S15.10.2.12_A1_T1.js")
+	data, err := os.ReadFile("testdata/S15.10.2.12_A1_T1.js")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/extract_failed_tests.sh
+++ b/extract_failed_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sed -En 's/^.*FAIL: TestTC39\/tc39\/(test\/.*.js).*$/"\1": true,/p'

--- a/file/file.go
+++ b/file/file.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -160,8 +161,14 @@ func (fl *File) Position(offset int) Position {
 
 	if fl.sourceMap != nil {
 		if source, _, row, col, ok := fl.sourceMap.Source(row, col); ok {
+			sourceUrlStr := source
+			sourceURL := ResolveSourcemapURL(fl.Name(), source)
+			if sourceURL != nil {
+				sourceUrlStr = sourceURL.String()
+			}
+
 			return Position{
-				Filename: ResolveSourcemapURL(fl.Name(), source).String(),
+				Filename: sourceUrlStr,
 				Line:     row,
 				Column:   col,
 			}
@@ -177,14 +184,14 @@ func (fl *File) Position(offset int) Position {
 
 func ResolveSourcemapURL(basename, source string) *url.URL {
 	// if the url is absolute(has scheme) there is nothing to do
-	smURL, err := url.Parse(source)
+	smURL, err := url.Parse(strings.TrimSpace(source))
 	if err == nil && !smURL.IsAbs() {
-		baseURL, err1 := url.Parse(basename)
+		baseURL, err1 := url.Parse(strings.TrimSpace(basename))
 		if err1 == nil && path.IsAbs(baseURL.Path) {
 			smURL = baseURL.ResolveReference(smURL)
 		} else {
-			// pathological case where both are not absolute paths and using Resolve as above will produce an absolute
-			// one
+			// pathological case where both are not absolute paths and using Resolve
+			// as above will produce an absolute one
 			smURL, _ = url.Parse(path.Join(path.Dir(basename), smURL.Path))
 		}
 	}

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -61,6 +61,8 @@ func TestGetSourceFilename(t *testing.T) {
 		{"../test.js", "/somewhere/else/base.js", "/somewhere/test.js"},
 		{"../test.js", "file:///somewhere/else/base.js", "file:///somewhere/test.js"},
 		{"../test.js", "https://example.com/somewhere/else/base.js", "https://example.com/somewhere/test.js"},
+		{"\ntest.js", "base123.js", "test.js"},
+		{"\rtest2.js\t\n  ", "base123.js", "test2.js"},
 		// TODO find something that won't parse
 	}
 	for _, test := range tests {

--- a/func.go
+++ b/func.go
@@ -60,6 +60,11 @@ type nativeFuncObject struct {
 	construct func(args []Value, newTarget *Object) *Object
 }
 
+type wrappedFuncObject struct {
+	nativeFuncObject
+	wrapped reflect.Value
+}
+
 type boundFuncObject struct {
 	nativeFuncObject
 	wrapped *Object
@@ -67,6 +72,14 @@ type boundFuncObject struct {
 
 func (f *nativeFuncObject) export(*objectExportCtx) interface{} {
 	return f.f
+}
+
+func (f *wrappedFuncObject) exportType() reflect.Type {
+	return f.wrapped.Type()
+}
+
+func (f *wrappedFuncObject) export(*objectExportCtx) interface{} {
+	return f.wrapped.Interface()
 }
 
 func (f *funcObject) _addProto(n unistring.String) Value {

--- a/func_test.go
+++ b/func_test.go
@@ -1,6 +1,7 @@
 package goja
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -114,6 +115,26 @@ func TestWrappedFunc(t *testing.T) {
 	assert(!f(0, ""));
 	`
 	vm.testScriptWithTestLib(SCRIPT, _undefined, t)
+}
+
+func TestWrappedFuncErrorPassthrough(t *testing.T) {
+	vm := New()
+	e := errors.New("test")
+	f := func(a int) error {
+		if a > 0 {
+			return e
+		}
+		return nil
+	}
+
+	var f1 func(a int64) error
+	err := vm.ExportTo(vm.ToValue(f), &f1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f1(1); err != e {
+		t.Fatal(err)
+	}
 }
 
 func ExampleAssertConstructor() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dop251/goja
 
-go 1.14
+go 1.16
 
 require (
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91

--- a/goja/main.go
+++ b/goja/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"os"
@@ -23,9 +23,9 @@ var timelimit = flag.Int("timelimit", 0, "max time to run (in seconds)")
 
 func readSource(filename string) ([]byte, error) {
 	if filename == "" || filename == "-" {
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	}
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func load(vm *goja.Runtime, call goja.FunctionCall) goja.Value {
@@ -71,7 +71,7 @@ func run() error {
 	})
 
 	vm.Set("readFile", func(name string) (string, error) {
-		b, err := ioutil.ReadFile(name)
+		b, err := os.ReadFile(name)
 		if err != nil {
 			return "", err
 		}

--- a/object_goarray_reflect.go
+++ b/object_goarray_reflect.go
@@ -70,18 +70,18 @@ func (o *objectGoArrayReflect) init() {
 }
 
 func (o *objectGoArrayReflect) updateLen() {
-	o.lengthProp.value = intToValue(int64(o.value.Len()))
+	o.lengthProp.value = intToValue(int64(o.fieldsValue.Len()))
 }
 
 func (o *objectGoArrayReflect) _hasIdx(idx valueInt) bool {
-	if idx := int64(idx); idx >= 0 && idx < int64(o.value.Len()) {
+	if idx := int64(idx); idx >= 0 && idx < int64(o.fieldsValue.Len()) {
 		return true
 	}
 	return false
 }
 
 func (o *objectGoArrayReflect) _hasStr(name unistring.String) bool {
-	if idx := strToIdx64(name); idx >= 0 && idx < int64(o.value.Len()) {
+	if idx := strToIdx64(name); idx >= 0 && idx < int64(o.fieldsValue.Len()) {
 		return true
 	}
 	return false
@@ -92,7 +92,7 @@ func (o *objectGoArrayReflect) _getIdx(idx int) Value {
 		return v.esValue()
 	}
 
-	v := o.value.Index(idx)
+	v := o.fieldsValue.Index(idx)
 
 	res, w := o.elemToValue(v)
 	if w != nil {
@@ -103,7 +103,7 @@ func (o *objectGoArrayReflect) _getIdx(idx int) Value {
 }
 
 func (o *objectGoArrayReflect) getIdx(idx valueInt, receiver Value) Value {
-	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.value.Len() {
+	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.fieldsValue.Len() {
 		return o._getIdx(idx)
 	}
 	return o.objectGoReflect.getStr(idx.string(), receiver)
@@ -111,7 +111,7 @@ func (o *objectGoArrayReflect) getIdx(idx valueInt, receiver Value) Value {
 
 func (o *objectGoArrayReflect) getStr(name unistring.String, receiver Value) Value {
 	var ownProp Value
-	if idx := strToGoIdx(name); idx >= 0 && idx < o.value.Len() {
+	if idx := strToGoIdx(name); idx >= 0 && idx < o.fieldsValue.Len() {
 		ownProp = o._getIdx(idx)
 	} else if name == "length" {
 		ownProp = &o.lengthProp
@@ -123,7 +123,7 @@ func (o *objectGoArrayReflect) getStr(name unistring.String, receiver Value) Val
 
 func (o *objectGoArrayReflect) getOwnPropStr(name unistring.String) Value {
 	if idx := strToGoIdx(name); idx >= 0 {
-		if idx < o.value.Len() {
+		if idx < o.fieldsValue.Len() {
 			return &valueProperty{
 				value:      o._getIdx(idx),
 				writable:   true,
@@ -139,7 +139,7 @@ func (o *objectGoArrayReflect) getOwnPropStr(name unistring.String) Value {
 }
 
 func (o *objectGoArrayReflect) getOwnPropIdx(idx valueInt) Value {
-	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.value.Len() {
+	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.fieldsValue.Len() {
 		return &valueProperty{
 			value:      o._getIdx(idx),
 			writable:   true,
@@ -155,7 +155,7 @@ func (o *objectGoArrayReflect) _putIdx(idx int, v Value, throw bool) bool {
 		copyReflectValueWrapper(cached)
 	}
 
-	rv := o.value.Index(idx)
+	rv := o.fieldsValue.Index(idx)
 	err := o.val.runtime.toReflectValue(v, rv, &objectExportCtx{})
 	if err != nil {
 		if cached != nil {
@@ -172,7 +172,7 @@ func (o *objectGoArrayReflect) _putIdx(idx int, v Value, throw bool) bool {
 
 func (o *objectGoArrayReflect) setOwnIdx(idx valueInt, val Value, throw bool) bool {
 	if i := toIntStrict(int64(idx)); i >= 0 {
-		if i >= o.value.Len() {
+		if i >= o.fieldsValue.Len() {
 			if res, ok := o._setForeignIdx(idx, nil, val, o.val, throw); ok {
 				return res
 			}
@@ -191,7 +191,7 @@ func (o *objectGoArrayReflect) setOwnIdx(idx valueInt, val Value, throw bool) bo
 
 func (o *objectGoArrayReflect) setOwnStr(name unistring.String, val Value, throw bool) bool {
 	if idx := strToGoIdx(name); idx >= 0 {
-		if idx >= o.value.Len() {
+		if idx >= o.fieldsValue.Len() {
 			if res, ok := o._setForeignStr(name, nil, val, o.val, throw); ok {
 				return res
 			}
@@ -261,13 +261,13 @@ func (o *objectGoArrayReflect) toPrimitive() Value {
 }
 
 func (o *objectGoArrayReflect) _deleteIdx(idx int) {
-	if idx < o.value.Len() {
+	if idx < o.fieldsValue.Len() {
 		if cv := o.valueCache.get(idx); cv != nil {
 			copyReflectValueWrapper(cv)
 			o.valueCache[idx] = nil
 		}
 
-		o.value.Index(idx).Set(reflect.Zero(o.value.Type().Elem()))
+		o.fieldsValue.Index(idx).Set(reflect.Zero(o.fieldsValue.Type().Elem()))
 	}
 }
 
@@ -294,7 +294,7 @@ type goArrayReflectPropIter struct {
 }
 
 func (i *goArrayReflectPropIter) next() (propIterItem, iterNextFunc) {
-	if i.idx < i.limit && i.idx < i.o.value.Len() {
+	if i.idx < i.limit && i.idx < i.o.fieldsValue.Len() {
 		name := strconv.Itoa(i.idx)
 		i.idx++
 		return propIterItem{name: asciiString(name), enumerable: _ENUM_TRUE}, i.next
@@ -304,7 +304,7 @@ func (i *goArrayReflectPropIter) next() (propIterItem, iterNextFunc) {
 }
 
 func (o *objectGoArrayReflect) stringKeys(all bool, accum []Value) []Value {
-	for i := 0; i < o.value.Len(); i++ {
+	for i := 0; i < o.fieldsValue.Len(); i++ {
 		accum = append(accum, asciiString(strconv.Itoa(i)))
 	}
 
@@ -314,12 +314,12 @@ func (o *objectGoArrayReflect) stringKeys(all bool, accum []Value) []Value {
 func (o *objectGoArrayReflect) iterateStringKeys() iterNextFunc {
 	return (&goArrayReflectPropIter{
 		o:     o,
-		limit: o.value.Len(),
+		limit: o.fieldsValue.Len(),
 	}).next
 }
 
 func (o *objectGoArrayReflect) sortLen() int {
-	return o.value.Len()
+	return o.fieldsValue.Len()
 }
 
 func (o *objectGoArrayReflect) sortGet(i int) Value {
@@ -327,9 +327,9 @@ func (o *objectGoArrayReflect) sortGet(i int) Value {
 }
 
 func (o *objectGoArrayReflect) swap(i int, j int) {
-	vi := o.value.Index(i)
-	vj := o.value.Index(j)
-	tmp := reflect.New(o.value.Type().Elem()).Elem()
+	vi := o.fieldsValue.Index(i)
+	vj := o.fieldsValue.Index(j)
+	tmp := reflect.New(o.fieldsValue.Type().Elem()).Elem()
 	tmp.Set(vi)
 	vi.Set(vj)
 	vj.Set(tmp)

--- a/object_gomap_reflect.go
+++ b/object_gomap_reflect.go
@@ -41,7 +41,7 @@ func (o *objectGoMapReflect) _get(n Value) Value {
 		return nil
 	}
 	if v := o.fieldsValue.MapIndex(key); v.IsValid() {
-		return o.val.runtime.ToValue(v.Interface())
+		return o.val.runtime.toValue(v.Interface(), v)
 	}
 
 	return nil
@@ -53,7 +53,7 @@ func (o *objectGoMapReflect) _getStr(name string) Value {
 		return nil
 	}
 	if v := o.fieldsValue.MapIndex(key); v.IsValid() {
-		return o.val.runtime.ToValue(v.Interface())
+		return o.val.runtime.toValue(v.Interface(), v)
 	}
 
 	return nil

--- a/object_gomap_reflect.go
+++ b/object_gomap_reflect.go
@@ -14,8 +14,8 @@ type objectGoMapReflect struct {
 
 func (o *objectGoMapReflect) init() {
 	o.objectGoReflect.init()
-	o.keyType = o.value.Type().Key()
-	o.valueType = o.value.Type().Elem()
+	o.keyType = o.fieldsValue.Type().Key()
+	o.valueType = o.fieldsValue.Type().Elem()
 }
 
 func (o *objectGoMapReflect) toKey(n Value, throw bool) reflect.Value {
@@ -40,7 +40,7 @@ func (o *objectGoMapReflect) _get(n Value) Value {
 	if !key.IsValid() {
 		return nil
 	}
-	if v := o.value.MapIndex(key); v.IsValid() {
+	if v := o.fieldsValue.MapIndex(key); v.IsValid() {
 		return o.val.runtime.ToValue(v.Interface())
 	}
 
@@ -52,7 +52,7 @@ func (o *objectGoMapReflect) _getStr(name string) Value {
 	if !key.IsValid() {
 		return nil
 	}
-	if v := o.value.MapIndex(key); v.IsValid() {
+	if v := o.fieldsValue.MapIndex(key); v.IsValid() {
 		return o.val.runtime.ToValue(v.Interface())
 	}
 
@@ -108,12 +108,12 @@ func (o *objectGoMapReflect) toValue(val Value, throw bool) (reflect.Value, bool
 
 func (o *objectGoMapReflect) _put(key reflect.Value, val Value, throw bool) bool {
 	if key.IsValid() {
-		if o.extensible || o.value.MapIndex(key).IsValid() {
+		if o.extensible || o.fieldsValue.MapIndex(key).IsValid() {
 			v, ok := o.toValue(val, throw)
 			if !ok {
 				return false
 			}
-			o.value.SetMapIndex(key, v)
+			o.fieldsValue.SetMapIndex(key, v)
 		} else {
 			o.val.runtime.typeErrorResult(throw, "Cannot set property %s, object is not extensible", key.String())
 			return false
@@ -126,7 +126,7 @@ func (o *objectGoMapReflect) _put(key reflect.Value, val Value, throw bool) bool
 func (o *objectGoMapReflect) setOwnStr(name unistring.String, val Value, throw bool) bool {
 	n := name.String()
 	key := o.strToKey(n, false)
-	if !key.IsValid() || !o.value.MapIndex(key).IsValid() {
+	if !key.IsValid() || !o.fieldsValue.MapIndex(key).IsValid() {
 		if proto := o.prototype; proto != nil {
 			// we know it's foreign because prototype loops are not allowed
 			if res, ok := proto.self.setForeignStr(name, val, o.val, throw); ok {
@@ -150,7 +150,7 @@ func (o *objectGoMapReflect) setOwnStr(name unistring.String, val Value, throw b
 
 func (o *objectGoMapReflect) setOwnIdx(idx valueInt, val Value, throw bool) bool {
 	key := o.toKey(idx, false)
-	if !key.IsValid() || !o.value.MapIndex(key).IsValid() {
+	if !key.IsValid() || !o.fieldsValue.MapIndex(key).IsValid() {
 		if proto := o.prototype; proto != nil {
 			// we know it's foreign because prototype loops are not allowed
 			if res, ok := proto.self.setForeignIdx(idx, val, o.val, throw); ok {
@@ -198,7 +198,7 @@ func (o *objectGoMapReflect) defineOwnPropertyIdx(idx valueInt, descr PropertyDe
 
 func (o *objectGoMapReflect) hasOwnPropertyStr(name unistring.String) bool {
 	key := o.strToKey(name.String(), false)
-	if key.IsValid() && o.value.MapIndex(key).IsValid() {
+	if key.IsValid() && o.fieldsValue.MapIndex(key).IsValid() {
 		return true
 	}
 	return false
@@ -206,7 +206,7 @@ func (o *objectGoMapReflect) hasOwnPropertyStr(name unistring.String) bool {
 
 func (o *objectGoMapReflect) hasOwnPropertyIdx(idx valueInt) bool {
 	key := o.toKey(idx, false)
-	if key.IsValid() && o.value.MapIndex(key).IsValid() {
+	if key.IsValid() && o.fieldsValue.MapIndex(key).IsValid() {
 		return true
 	}
 	return false
@@ -217,7 +217,7 @@ func (o *objectGoMapReflect) deleteStr(name unistring.String, throw bool) bool {
 	if !key.IsValid() {
 		return false
 	}
-	o.value.SetMapIndex(key, reflect.Value{})
+	o.fieldsValue.SetMapIndex(key, reflect.Value{})
 	return true
 }
 
@@ -226,7 +226,7 @@ func (o *objectGoMapReflect) deleteIdx(idx valueInt, throw bool) bool {
 	if !key.IsValid() {
 		return false
 	}
-	o.value.SetMapIndex(key, reflect.Value{})
+	o.fieldsValue.SetMapIndex(key, reflect.Value{})
 	return true
 }
 
@@ -239,7 +239,7 @@ type gomapReflectPropIter struct {
 func (i *gomapReflectPropIter) next() (propIterItem, iterNextFunc) {
 	for i.idx < len(i.keys) {
 		key := i.keys[i.idx]
-		v := i.o.value.MapIndex(key)
+		v := i.o.fieldsValue.MapIndex(key)
 		i.idx++
 		if v.IsValid() {
 			return propIterItem{name: newStringValue(key.String()), enumerable: _ENUM_TRUE}, i.next
@@ -252,13 +252,13 @@ func (i *gomapReflectPropIter) next() (propIterItem, iterNextFunc) {
 func (o *objectGoMapReflect) iterateStringKeys() iterNextFunc {
 	return (&gomapReflectPropIter{
 		o:    o,
-		keys: o.value.MapKeys(),
+		keys: o.fieldsValue.MapKeys(),
 	}).next
 }
 
 func (o *objectGoMapReflect) stringKeys(_ bool, accum []Value) []Value {
 	// all own keys are enumerable
-	for _, key := range o.value.MapKeys() {
+	for _, key := range o.fieldsValue.MapKeys() {
 		accum = append(accum, newStringValue(key.String()))
 	}
 

--- a/object_goreflect.go
+++ b/object_goreflect.go
@@ -234,17 +234,13 @@ func (o *objectGoReflect) _getMethod(jsName string) reflect.Value {
 
 func (o *objectGoReflect) elemToValue(ev reflect.Value) (Value, reflectValueWrapper) {
 	if isContainer(ev.Kind()) {
-		if ev.Type() == reflectTypeArray {
-			a := o.val.runtime.newObjectGoSlice(ev.Addr().Interface().(*[]interface{}))
-			return a.val, a
-		}
-		ret := o.val.runtime.reflectValueToValue(ev)
+		ret := o.val.runtime.toValue(ev.Interface(), ev)
 		if obj, ok := ret.(*Object); ok {
 			if w, ok := obj.self.(reflectValueWrapper); ok {
 				return ret, w
 			}
 		}
-		panic("reflectValueToValue() returned a value which is not a reflectValueWrapper")
+		return ret, nil
 	}
 
 	for ev.Kind() == reflect.Interface {
@@ -255,7 +251,7 @@ func (o *objectGoReflect) elemToValue(ev reflect.Value) (Value, reflectValueWrap
 		return _null, nil
 	}
 
-	return o.val.runtime.ToValue(ev.Interface()), nil
+	return o.val.runtime.toValue(ev.Interface(), ev), nil
 }
 
 func (o *objectGoReflect) _getFieldValue(name string) Value {
@@ -283,7 +279,7 @@ func (o *objectGoReflect) _get(name string) Value {
 	}
 
 	if v := o._getMethod(name); v.IsValid() {
-		return o.val.runtime.reflectValueToValue(v)
+		return o.val.runtime.toValue(v.Interface(), v)
 	}
 
 	return nil
@@ -303,7 +299,7 @@ func (o *objectGoReflect) getOwnPropStr(name unistring.String) Value {
 
 	if v := o._getMethod(n); v.IsValid() {
 		return &valueProperty{
-			value:      o.val.runtime.reflectValueToValue(v),
+			value:      o.val.runtime.toValue(v.Interface(), v),
 			enumerable: true,
 		}
 	}

--- a/object_goreflect.go
+++ b/object_goreflect.go
@@ -154,7 +154,7 @@ func (o *objectGoReflect) init() {
 	// Always use pointer type for non-interface values to be able to access both methods defined on
 	// the literal type and on the pointer.
 	if o.fieldsValue.Kind() != reflect.Interface {
-		methodsType = reflect.PointerTo(o.fieldsValue.Type())
+		methodsType = reflect.PtrTo(o.fieldsValue.Type())
 	} else {
 		methodsType = o.fieldsValue.Type()
 	}

--- a/object_goreflect.go
+++ b/object_goreflect.go
@@ -70,10 +70,14 @@ type reflectFieldInfo struct {
 	Anonymous bool
 }
 
-type reflectTypeInfo struct {
-	Fields                  map[string]reflectFieldInfo
-	Methods                 map[string]int
-	FieldNames, MethodNames []string
+type reflectFieldsInfo struct {
+	Fields map[string]reflectFieldInfo
+	Names  []string
+}
+
+type reflectMethodsInfo struct {
+	Methods map[string]int
+	Names   []string
 }
 
 type reflectValueWrapper interface {
@@ -99,9 +103,12 @@ func copyReflectValueWrapper(w reflectValueWrapper) {
 
 type objectGoReflect struct {
 	baseObject
-	origValue, value reflect.Value
+	origValue, fieldsValue reflect.Value
 
-	valueTypeInfo, origValueTypeInfo *reflectTypeInfo
+	fieldsInfo  *reflectFieldsInfo
+	methodsInfo *reflectMethodsInfo
+
+	methodsValue reflect.Value
 
 	valueCache map[string]reflectValueWrapper
 
@@ -112,7 +119,7 @@ type objectGoReflect struct {
 
 func (o *objectGoReflect) init() {
 	o.baseObject.init()
-	switch o.value.Kind() {
+	switch o.fieldsValue.Kind() {
 	case reflect.Bool:
 		o.class = classBoolean
 		o.prototype = o.val.runtime.global.BooleanPrototype
@@ -137,13 +144,34 @@ func (o *objectGoReflect) init() {
 	default:
 		o.class = classObject
 		o.prototype = o.val.runtime.global.ObjectPrototype
-		if !o.value.CanAddr() {
-			value := reflect.New(o.value.Type()).Elem()
-			value.Set(o.value)
-			o.origValue = value
-			o.value = value
+	}
+
+	if o.fieldsValue.Kind() == reflect.Struct {
+		o.fieldsInfo = o.val.runtime.fieldsInfo(o.fieldsValue.Type())
+	}
+
+	var methodsType reflect.Type
+	// Always use pointer type for non-interface values to be able to access both methods defined on
+	// the literal type and on the pointer.
+	if o.fieldsValue.Kind() != reflect.Interface {
+		methodsType = reflect.PointerTo(o.fieldsValue.Type())
+	} else {
+		methodsType = o.fieldsValue.Type()
+	}
+
+	o.methodsInfo = o.val.runtime.methodsInfo(methodsType)
+
+	// Container values and values that have at least one method defined on the pointer type
+	// need to be addressable.
+	if !o.origValue.CanAddr() && (isContainer(o.origValue.Kind()) || len(o.methodsInfo.Names) > 0) {
+		value := reflect.New(o.origValue.Type()).Elem()
+		value.Set(o.origValue)
+		o.origValue = value
+		if value.Kind() != reflect.Ptr {
+			o.fieldsValue = value
 		}
 	}
+
 	o.extensible = true
 
 	switch o.origValue.Interface().(type) {
@@ -158,8 +186,11 @@ func (o *objectGoReflect) init() {
 		o.baseObject._putProp("valueOf", o.val.runtime.newNativeFunc(o.valueOfFunc, nil, "valueOf", nil, 0), true, false, true)
 	}
 
-	o.valueTypeInfo = o.val.runtime.typeInfo(o.value.Type())
-	o.origValueTypeInfo = o.val.runtime.typeInfo(o.origValue.Type())
+	if len(o.methodsInfo.Names) > 0 && o.fieldsValue.Kind() != reflect.Interface {
+		o.methodsValue = o.fieldsValue.Addr()
+	} else {
+		o.methodsValue = o.fieldsValue
+	}
 
 	if j, ok := o.origValue.Interface().(JsonEncodable); ok {
 		o.toJson = j.JsonEncodable
@@ -182,16 +213,20 @@ func (o *objectGoReflect) getStr(name unistring.String, receiver Value) Value {
 }
 
 func (o *objectGoReflect) _getField(jsName string) reflect.Value {
-	if info, exists := o.valueTypeInfo.Fields[jsName]; exists {
-		return o.value.FieldByIndex(info.Index)
+	if o.fieldsInfo != nil {
+		if info, exists := o.fieldsInfo.Fields[jsName]; exists {
+			return o.fieldsValue.FieldByIndex(info.Index)
+		}
 	}
 
 	return reflect.Value{}
 }
 
 func (o *objectGoReflect) _getMethod(jsName string) reflect.Value {
-	if idx, exists := o.origValueTypeInfo.Methods[jsName]; exists {
-		return o.origValue.Method(idx)
+	if o.methodsInfo != nil {
+		if idx, exists := o.methodsInfo.Methods[jsName]; exists {
+			return o.methodsValue.Method(idx)
+		}
 	}
 
 	return reflect.Value{}
@@ -241,7 +276,7 @@ func (o *objectGoReflect) _getFieldValue(name string) Value {
 }
 
 func (o *objectGoReflect) _get(name string) Value {
-	if o.value.Kind() == reflect.Struct {
+	if o.fieldsValue.Kind() == reflect.Struct {
 		if ret := o._getFieldValue(name); ret != nil {
 			return ret
 		}
@@ -256,7 +291,7 @@ func (o *objectGoReflect) _get(name string) Value {
 
 func (o *objectGoReflect) getOwnPropStr(name unistring.String) Value {
 	n := name.String()
-	if o.value.Kind() == reflect.Struct {
+	if o.fieldsValue.Kind() == reflect.Struct {
 		if v := o._getFieldValue(n); v != nil {
 			return &valueProperty{
 				value:      v,
@@ -298,7 +333,7 @@ func (o *objectGoReflect) setForeignIdx(idx valueInt, val, receiver Value, throw
 }
 
 func (o *objectGoReflect) _put(name string, val Value, throw bool) (has, ok bool) {
-	if o.value.Kind() == reflect.Struct {
+	if o.fieldsValue.Kind() == reflect.Struct {
 		if v := o._getField(name); v.IsValid() {
 			cached := o.valueCache[name]
 			if cached != nil {
@@ -359,7 +394,7 @@ func (o *objectGoReflect) defineOwnPropertyStr(name unistring.String, descr Prop
 }
 
 func (o *objectGoReflect) _has(name string) bool {
-	if o.value.Kind() == reflect.Struct {
+	if o.fieldsValue.Kind() == reflect.Struct {
 		if v := o._getField(name); v.IsValid() {
 			return true
 		}
@@ -375,15 +410,15 @@ func (o *objectGoReflect) hasOwnPropertyStr(name unistring.String) bool {
 }
 
 func (o *objectGoReflect) _valueOfInt() Value {
-	return intToValue(o.value.Int())
+	return intToValue(o.fieldsValue.Int())
 }
 
 func (o *objectGoReflect) _valueOfUint() Value {
-	return intToValue(int64(o.value.Uint()))
+	return intToValue(int64(o.fieldsValue.Uint()))
 }
 
 func (o *objectGoReflect) _valueOfBool() Value {
-	if o.value.Bool() {
+	if o.fieldsValue.Bool() {
 		return valueTrue
 	} else {
 		return valueFalse
@@ -391,7 +426,7 @@ func (o *objectGoReflect) _valueOfBool() Value {
 }
 
 func (o *objectGoReflect) _valueOfFloat() Value {
-	return floatToValue(o.value.Float())
+	return floatToValue(o.fieldsValue.Float())
 }
 
 func (o *objectGoReflect) _toStringStringer() Value {
@@ -399,11 +434,11 @@ func (o *objectGoReflect) _toStringStringer() Value {
 }
 
 func (o *objectGoReflect) _toStringString() Value {
-	return newStringValue(o.value.String())
+	return newStringValue(o.fieldsValue.String())
 }
 
 func (o *objectGoReflect) _toStringBool() Value {
-	if o.value.Bool() {
+	if o.fieldsValue.Bool() {
 		return stringTrue
 	} else {
 		return stringFalse
@@ -460,7 +495,7 @@ type goreflectPropIter struct {
 }
 
 func (i *goreflectPropIter) nextField() (propIterItem, iterNextFunc) {
-	names := i.o.valueTypeInfo.FieldNames
+	names := i.o.fieldsInfo.Names
 	if i.idx < len(names) {
 		name := names[i.idx]
 		i.idx++
@@ -472,7 +507,7 @@ func (i *goreflectPropIter) nextField() (propIterItem, iterNextFunc) {
 }
 
 func (i *goreflectPropIter) nextMethod() (propIterItem, iterNextFunc) {
-	names := i.o.origValueTypeInfo.MethodNames
+	names := i.o.methodsInfo.Names
 	if i.idx < len(names) {
 		name := names[i.idx]
 		i.idx++
@@ -486,7 +521,7 @@ func (o *objectGoReflect) iterateStringKeys() iterNextFunc {
 	r := &goreflectPropIter{
 		o: o,
 	}
-	if o.value.Kind() == reflect.Struct {
+	if o.fieldsInfo != nil {
 		return r.nextField
 	}
 
@@ -495,11 +530,13 @@ func (o *objectGoReflect) iterateStringKeys() iterNextFunc {
 
 func (o *objectGoReflect) stringKeys(_ bool, accum []Value) []Value {
 	// all own keys are enumerable
-	for _, name := range o.valueTypeInfo.FieldNames {
-		accum = append(accum, newStringValue(name))
+	if o.fieldsInfo != nil {
+		for _, name := range o.fieldsInfo.Names {
+			accum = append(accum, newStringValue(name))
+		}
 	}
 
-	for _, name := range o.valueTypeInfo.MethodNames {
+	for _, name := range o.methodsInfo.Names {
 		accum = append(accum, newStringValue(name))
 	}
 
@@ -516,31 +553,32 @@ func (o *objectGoReflect) exportType() reflect.Type {
 
 func (o *objectGoReflect) equal(other objectImpl) bool {
 	if other, ok := other.(*objectGoReflect); ok {
-		k1, k2 := o.value.Kind(), other.value.Kind()
+		k1, k2 := o.fieldsValue.Kind(), other.fieldsValue.Kind()
 		if k1 == k2 {
 			if isContainer(k1) {
-				return o.value == other.value
+				return o.fieldsValue == other.fieldsValue
 			}
-			return o.value.Interface() == other.value.Interface()
+			return o.fieldsValue.Interface() == other.fieldsValue.Interface()
 		}
 	}
 	return false
 }
 
 func (o *objectGoReflect) reflectValue() reflect.Value {
-	return o.value
+	return o.fieldsValue
 }
 
 func (o *objectGoReflect) setReflectValue(v reflect.Value) {
-	o.value = v
+	o.fieldsValue = v
 	o.origValue = v
+	o.methodsValue = v.Addr()
 }
 
 func (o *objectGoReflect) esValue() Value {
 	return o.val
 }
 
-func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectTypeInfo) {
+func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectFieldsInfo) {
 	n := t.NumField()
 	for i := 0; i < n; i++ {
 		field := t.Field(i)
@@ -554,7 +592,7 @@ func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectTypeI
 
 		if name != "" {
 			if inf, exists := info.Fields[name]; !exists {
-				info.FieldNames = append(info.FieldNames, name)
+				info.Names = append(info.Names, name)
 			} else {
 				if len(inf.Index) <= len(index) {
 					continue
@@ -586,18 +624,16 @@ func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectTypeI
 	}
 }
 
-func (r *Runtime) buildTypeInfo(t reflect.Type) (info *reflectTypeInfo) {
-	info = new(reflectTypeInfo)
-	if t.Kind() == reflect.Struct {
-		info.Fields = make(map[string]reflectFieldInfo)
-		n := t.NumField()
-		info.FieldNames = make([]string, 0, n)
-		r.buildFieldInfo(t, nil, info)
-	}
+var emptyMethodsInfo = reflectMethodsInfo{}
 
-	info.Methods = make(map[string]int)
+func (r *Runtime) buildMethodsInfo(t reflect.Type) (info *reflectMethodsInfo) {
 	n := t.NumMethod()
-	info.MethodNames = make([]string, 0, n)
+	if n == 0 {
+		return &emptyMethodsInfo
+	}
+	info = new(reflectMethodsInfo)
+	info.Methods = make(map[string]int, n)
+	info.Names = make([]string, 0, n)
 	for i := 0; i < n; i++ {
 		method := t.Method(i)
 		name := method.Name
@@ -612,7 +648,7 @@ func (r *Runtime) buildTypeInfo(t reflect.Type) (info *reflectTypeInfo) {
 		}
 
 		if _, exists := info.Methods[name]; !exists {
-			info.MethodNames = append(info.MethodNames, name)
+			info.Names = append(info.Names, name)
 		}
 
 		info.Methods[name] = i
@@ -620,14 +656,36 @@ func (r *Runtime) buildTypeInfo(t reflect.Type) (info *reflectTypeInfo) {
 	return
 }
 
-func (r *Runtime) typeInfo(t reflect.Type) (info *reflectTypeInfo) {
+func (r *Runtime) buildFieldsInfo(t reflect.Type) (info *reflectFieldsInfo) {
+	info = new(reflectFieldsInfo)
+	n := t.NumField()
+	info.Fields = make(map[string]reflectFieldInfo, n)
+	info.Names = make([]string, 0, n)
+	r.buildFieldInfo(t, nil, info)
+	return
+}
+
+func (r *Runtime) fieldsInfo(t reflect.Type) (info *reflectFieldsInfo) {
 	var exists bool
-	if info, exists = r.typeInfoCache[t]; !exists {
-		info = r.buildTypeInfo(t)
-		if r.typeInfoCache == nil {
-			r.typeInfoCache = make(map[reflect.Type]*reflectTypeInfo)
+	if info, exists = r.fieldsInfoCache[t]; !exists {
+		info = r.buildFieldsInfo(t)
+		if r.fieldsInfoCache == nil {
+			r.fieldsInfoCache = make(map[reflect.Type]*reflectFieldsInfo)
 		}
-		r.typeInfoCache[t] = info
+		r.fieldsInfoCache[t] = info
+	}
+
+	return
+}
+
+func (r *Runtime) methodsInfo(t reflect.Type) (info *reflectMethodsInfo) {
+	var exists bool
+	if info, exists = r.methodsInfoCache[t]; !exists {
+		info = r.buildMethodsInfo(t)
+		if r.methodsInfoCache == nil {
+			r.methodsInfoCache = make(map[reflect.Type]*reflectMethodsInfo)
+		}
+		r.methodsInfoCache[t] = info
 	}
 
 	return
@@ -639,7 +697,8 @@ func (r *Runtime) typeInfo(t reflect.Type) (info *reflectTypeInfo) {
 // original unchanged names.
 func (r *Runtime) SetFieldNameMapper(mapper FieldNameMapper) {
 	r.fieldNameMapper = mapper
-	r.typeInfoCache = nil
+	r.fieldsInfoCache = nil
+	r.methodsInfoCache = nil
 }
 
 // TagFieldNameMapper returns a FieldNameMapper that uses the given tagName for struct fields and optionally

--- a/object_goreflect_test.go
+++ b/object_goreflect_test.go
@@ -1520,3 +1520,42 @@ func TestGoReflectToPrimitive(t *testing.T) {
 		})
 	})
 }
+
+type testGoReflectFuncRt struct {
+}
+
+func (*testGoReflectFuncRt) M(call FunctionCall, r *Runtime) Value {
+	if r == nil {
+		panic(typeError("Runtime is nil"))
+	}
+	return call.Argument(0)
+}
+
+func (*testGoReflectFuncRt) C(call ConstructorCall, r *Runtime) *Object {
+	if r == nil {
+		panic(typeError("Runtime is nil in constructor"))
+	}
+	call.This.Set("r", call.Argument(0))
+	return nil
+}
+
+func TestGoReflectFuncWithRuntime(t *testing.T) {
+	vm := New()
+	var s testGoReflectFuncRt
+	vm.Set("s", &s)
+	res, err := vm.RunString("s.M(true)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != valueTrue {
+		t.Fatal(res)
+	}
+
+	res, err = vm.RunString("new s.C(true).r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != valueTrue {
+		t.Fatal(res)
+	}
+}

--- a/object_goslice_reflect.go
+++ b/object_goslice_reflect.go
@@ -19,46 +19,46 @@ func (o *objectGoSliceReflect) init() {
 }
 
 func (o *objectGoSliceReflect) _putIdx(idx int, v Value, throw bool) bool {
-	if idx >= o.value.Len() {
+	if idx >= o.fieldsValue.Len() {
 		o.grow(idx + 1)
 	}
 	return o.objectGoArrayReflect._putIdx(idx, v, throw)
 }
 
 func (o *objectGoSliceReflect) grow(size int) {
-	oldcap := o.value.Cap()
+	oldcap := o.fieldsValue.Cap()
 	if oldcap < size {
-		n := reflect.MakeSlice(o.value.Type(), size, growCap(size, o.value.Len(), oldcap))
-		reflect.Copy(n, o.value)
-		o.value.Set(n)
+		n := reflect.MakeSlice(o.fieldsValue.Type(), size, growCap(size, o.fieldsValue.Len(), oldcap))
+		reflect.Copy(n, o.fieldsValue)
+		o.fieldsValue.Set(n)
 		l := len(o.valueCache)
 		if l > size {
 			l = size
 		}
 		for i, w := range o.valueCache[:l] {
 			if w != nil {
-				w.setReflectValue(o.value.Index(i))
+				w.setReflectValue(o.fieldsValue.Index(i))
 			}
 		}
 	} else {
-		tail := o.value.Slice(o.value.Len(), size)
-		zero := reflect.Zero(o.value.Type().Elem())
+		tail := o.fieldsValue.Slice(o.fieldsValue.Len(), size)
+		zero := reflect.Zero(o.fieldsValue.Type().Elem())
 		for i := 0; i < tail.Len(); i++ {
 			tail.Index(i).Set(zero)
 		}
-		o.value.SetLen(size)
+		o.fieldsValue.SetLen(size)
 	}
 	o.updateLen()
 }
 
 func (o *objectGoSliceReflect) shrink(size int) {
 	o.valueCache.shrink(size)
-	tail := o.value.Slice(size, o.value.Len())
-	zero := reflect.Zero(o.value.Type().Elem())
+	tail := o.fieldsValue.Slice(size, o.fieldsValue.Len())
+	zero := reflect.Zero(o.fieldsValue.Type().Elem())
 	for i := 0; i < tail.Len(); i++ {
 		tail.Index(i).Set(zero)
 	}
-	o.value.SetLen(size)
+	o.fieldsValue.SetLen(size)
 	o.updateLen()
 }
 
@@ -67,7 +67,7 @@ func (o *objectGoSliceReflect) putLength(v uint32, throw bool) bool {
 		panic(rangeError("Integer value overflows 32-bit int"))
 	}
 	newLen := int(v)
-	curLen := o.value.Len()
+	curLen := o.fieldsValue.Len()
 	if newLen > curLen {
 		o.grow(newLen)
 	} else if newLen < curLen {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -425,6 +425,11 @@ func (self *_parser) scan() (tkn token.Token, literal string, parsedLiteral unis
 			case '`':
 				tkn = token.BACKTICK
 			case '#':
+				if self.chrOffset == 1 && self.chr == '!' {
+					self.skipSingleLineComment()
+					continue
+				}
+
 				var err string
 				literal, parsedLiteral, _, err = self.scanIdentifier()
 				if err != "" || literal == "" {

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -39,6 +39,15 @@ func TestLexer(t *testing.T) {
 			token.EOF, "", 1,
 		)
 
+		test("#!",
+			token.EOF, "", 3,
+		)
+
+		test("#!\n1",
+			token.NUMBER, "1", 4,
+			token.EOF, "", 5,
+		)
+
 		test("1",
 			token.NUMBER, "1", 1,
 			token.EOF, "", 2,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,7 +36,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/dop251/goja/ast"
 	"github.com/dop251/goja/file"
@@ -154,7 +154,7 @@ func ReadSource(filename string, src interface{}) ([]byte, error) {
 		}
 		return nil, errors.New("invalid source")
 	}
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 // ParseFile parses the source code of a single JavaScript/ECMAScript source file and returns

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -488,6 +488,7 @@ func (self *_parser) parseCaseStatement() *ast.CaseStatement {
 			self.token == token.DEFAULT {
 			break
 		}
+		self.scope.allowLet = true
 		node.Consequent = append(node.Consequent, self.parseStatement())
 
 	}

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/dop251/goja/ast"
@@ -843,7 +843,7 @@ func (self *_parser) parseSourceMap() file.SourceMapConsumer {
 					data, err = self.opts.sourceMapLoader(sourceURL.String())
 				} else {
 					if sourceURL.Scheme == "" || sourceURL.Scheme == "file" {
-						data, err = ioutil.ReadFile(sourceURL.Path)
+						data, err = os.ReadFile(sourceURL.Path)
 					} else {
 						err = fmt.Errorf("unsupported source map URL scheme: %s", sourceURL.Scheme)
 					}

--- a/regexp.go
+++ b/regexp.go
@@ -96,9 +96,9 @@ func (p *regexpPattern) createRegexp2() {
 	p.regexp2Wrapper = rx
 }
 
-func buildUTF8PosMap(s valueString) (positionMap, string) {
+func buildUTF8PosMap(s unicodeString) (positionMap, string) {
 	pm := make(positionMap, 0, s.length())
-	rd := s.reader(0)
+	rd := s.reader()
 	sPos, utf8Pos := 0, 0
 	var sb strings.Builder
 	for {
@@ -137,11 +137,12 @@ func (p *regexpPattern) findAllSubmatchIndex(s valueString, start int, limit int
 		return p.regexp2Wrapper.findAllSubmatchIndex(s, start, limit, sticky, p.unicode)
 	}
 	if start == 0 {
-		if s, ok := s.(asciiString); ok {
-			return p.regexpWrapper.findAllSubmatchIndex(s.String(), limit, sticky)
+		a, u := devirtualizeString(s)
+		if u == nil {
+			return p.regexpWrapper.findAllSubmatchIndex(string(a), limit, sticky)
 		}
 		if limit == 1 {
-			result := p.regexpWrapper.findSubmatchIndexUnicode(s.(unicodeString), p.unicode)
+			result := p.regexpWrapper.findSubmatchIndexUnicode(u, p.unicode)
 			if result == nil {
 				return nil
 			}
@@ -151,7 +152,7 @@ func (p *regexpPattern) findAllSubmatchIndex(s valueString, start int, limit int
 		// input.
 		if p.unicode {
 			// Try to convert s to UTF-8. If it does not contain any invalid UTF-16 we can do the matching in UTF-8.
-			pm, str := buildUTF8PosMap(s)
+			pm, str := buildUTF8PosMap(u)
 			if pm != nil {
 				res := p.regexpWrapper.findAllSubmatchIndex(str, limit, sticky)
 				for _, result := range res {
@@ -263,7 +264,7 @@ func (r *regexp2Wrapper) findUnicodeCached(s valueString, start int, doCache boo
 		runes, posMap = cache.runes, cache.posMap
 		mappedStart, splitPair = posMapReverseLookup(posMap, start)
 	} else {
-		posMap, runes, mappedStart, splitPair = buildPosMap(&lenientUtf16Decoder{utf16Reader: s.utf16Reader(0)}, s.length(), start)
+		posMap, runes, mappedStart, splitPair = buildPosMap(&lenientUtf16Decoder{utf16Reader: s.utf16Reader()}, s.length(), start)
 		cache = nil
 	}
 	if splitPair {
@@ -437,17 +438,14 @@ func (r *regexp2Wrapper) findAllSubmatchIndexUnicode(s unicodeString, start, lim
 }
 
 func (r *regexp2Wrapper) findAllSubmatchIndex(s valueString, start, limit int, sticky, fullUnicode bool) [][]int {
-	switch s := s.(type) {
-	case asciiString:
-		return r.findAllSubmatchIndexUTF16(s, start, limit, sticky)
-	case unicodeString:
+	a, u := devirtualizeString(s)
+	if u != nil {
 		if fullUnicode {
-			return r.findAllSubmatchIndexUnicode(s, start, limit, sticky)
+			return r.findAllSubmatchIndexUnicode(u, start, limit, sticky)
 		}
-		return r.findAllSubmatchIndexUTF16(s, start, limit, sticky)
-	default:
-		panic("Unsupported string type")
+		return r.findAllSubmatchIndexUTF16(u, start, limit, sticky)
 	}
+	return r.findAllSubmatchIndexUTF16(a, start, limit, sticky)
 }
 
 func (r *regexp2Wrapper) clone() *regexp2Wrapper {
@@ -474,14 +472,11 @@ func (r *regexpWrapper) findAllSubmatchIndex(s string, limit int, sticky bool) (
 }
 
 func (r *regexpWrapper) findSubmatchIndex(s valueString, fullUnicode bool) []int {
-	switch s := s.(type) {
-	case asciiString:
-		return r.findSubmatchIndexASCII(string(s))
-	case unicodeString:
-		return r.findSubmatchIndexUnicode(s, fullUnicode)
-	default:
-		panic("Unsupported string type")
+	a, u := devirtualizeString(s)
+	if u != nil {
+		return r.findSubmatchIndexUnicode(u, fullUnicode)
 	}
+	return r.findSubmatchIndexASCII(string(a))
 }
 
 func (r *regexpWrapper) findSubmatchIndexASCII(s string) []int {
@@ -492,7 +487,7 @@ func (r *regexpWrapper) findSubmatchIndexASCII(s string) []int {
 func (r *regexpWrapper) findSubmatchIndexUnicode(s unicodeString, fullUnicode bool) (result []int) {
 	wrapped := (*regexp.Regexp)(r)
 	if fullUnicode {
-		posMap, runes, _, _ := buildPosMap(&lenientUtf16Decoder{utf16Reader: s.utf16Reader(0)}, s.length(), 0)
+		posMap, runes, _, _ := buildPosMap(&lenientUtf16Decoder{utf16Reader: s.utf16Reader()}, s.length(), 0)
 		res := wrapped.FindReaderSubmatchIndex(&arrayRuneReader{runes: runes})
 		for i, item := range res {
 			if item >= 0 {
@@ -501,7 +496,7 @@ func (r *regexpWrapper) findSubmatchIndexUnicode(s unicodeString, fullUnicode bo
 		}
 		return res
 	}
-	return wrapped.FindReaderSubmatchIndex(s.utf16Reader(0))
+	return wrapped.FindReaderSubmatchIndex(s.utf16Reader())
 }
 
 func (r *regexpWrapper) clone() *regexpWrapper {

--- a/runtime.go
+++ b/runtime.go
@@ -963,34 +963,6 @@ func (r *Runtime) error_captureStackTrace(call FunctionCall) Value {
 	return newStringValue("")
 }
 
-func (r *Runtime) error_toString(call FunctionCall) Value {
-	var nameStr, msgStr valueString
-	obj := r.toObject(call.This)
-	name := obj.self.getStr("name", nil)
-	if name == nil || name == _undefined {
-		nameStr = asciiString("Error")
-	} else {
-		nameStr = name.toString()
-	}
-	msg := obj.self.getStr("message", nil)
-	if msg == nil || msg == _undefined {
-		msgStr = stringEmpty
-	} else {
-		msgStr = msg.toString()
-	}
-	if nameStr.length() == 0 {
-		return msgStr
-	}
-	if msgStr.length() == 0 {
-		return nameStr
-	}
-	var sb valueStringBuilder
-	sb.WriteString(nameStr)
-	sb.WriteString(asciiString(": "))
-	sb.WriteString(msgStr)
-	return sb.String()
-}
-
 func (r *Runtime) builtin_new(construct *Object, args []Value) *Object {
 	return r.toConstructor(construct)(args, nil)
 }

--- a/runtime.go
+++ b/runtime.go
@@ -1714,6 +1714,10 @@ UTF-8) conversion from JS to Go may be lossy. In particular, code points that ca
 (0xD800-0xDFFF) cannot be represented in UTF-8 unless they form a valid surrogate pair and are replaced with
 utf8.RuneError.
 
+The string value must be a valid UTF-8. If it is not, invalid characters are replaced with utf8.RuneError, but
+the behaviour of a subsequent Export() is unspecified (it may return the original value, or a value with replaced
+invalid characters).
+
 # Nil
 
 Nil is converted to null.
@@ -1876,7 +1880,14 @@ func (r *Runtime) ToValue(i interface{}) Value {
 	case Value:
 		return i
 	case string:
-		return newStringValue(i)
+		// return newStringValue(i)
+		if len(i) <= 16 {
+			if u := unistring.Scan(i); u != nil {
+				return &importedString{s: i, u: u, scanned: true}
+			}
+			return asciiString(i)
+		}
+		return &importedString{s: i}
 	case bool:
 		if i {
 			return valueTrue

--- a/runtime.go
+++ b/runtime.go
@@ -2839,7 +2839,15 @@ func (r *Runtime) getIterator(obj Value, method func(FunctionCall) Value) *itera
 		ctx:  r.vm.ctx,
 		This: obj,
 	}))
-	next := toMethod(iter.self.getStr("next", nil))
+
+	var next func(FunctionCall) Value
+
+	if obj, ok := iter.self.getStr("next", nil).(*Object); ok {
+		if call, ok := obj.self.assertCallable(); ok {
+			next = call
+		}
+	}
+
 	return &iteratorRecord{
 		iterator: iter,
 		next:     next,
@@ -2851,10 +2859,9 @@ func (ir *iteratorRecord) iterate(step func(Value)) {
 	r := ir.iterator.runtime
 	for {
 		if ir.next == nil {
-			panic(r.NewTypeError("object null is not a function"))
+			panic(r.NewTypeError("iterator.next is missing or not a function"))
 		}
-		nextVal := ir.next(FunctionCall{ctx: ir.ctx, This: ir.iterator})
-		res := r.toObject(nextVal)
+		res := r.toObject(ir.next(FunctionCall{ctx: ir.ctx, This: ir.iterator}))
 		if nilSafe(res.self.getStr("done", nil)).ToBoolean() {
 			break
 		}

--- a/runtime.go
+++ b/runtime.go
@@ -179,7 +179,9 @@ type Runtime struct {
 
 	symbolRegistry map[unistring.String]*Symbol
 
-	typeInfoCache   map[reflect.Type]*reflectTypeInfo
+	fieldsInfoCache  map[reflect.Type]*reflectFieldsInfo
+	methodsInfoCache map[reflect.Type]*reflectMethodsInfo
+
 	fieldNameMapper FieldNameMapper
 
 	vm    *vm
@@ -1983,7 +1985,7 @@ func (r *Runtime) ToValue(i interface{}) Value {
 func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 	value := origValue
 	for value.Kind() == reflect.Ptr {
-		value = reflect.Indirect(value)
+		value = value.Elem()
 	}
 
 	if !value.IsValid() {
@@ -2005,8 +2007,8 @@ func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 							val:        obj,
 							extensible: true,
 						},
-						origValue: origValue,
-						value:     value,
+						origValue:   origValue,
+						fieldsValue: value,
 					},
 				}
 				m.init()
@@ -2021,8 +2023,8 @@ func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 				baseObject: baseObject{
 					val: obj,
 				},
-				origValue: origValue,
-				value:     value,
+				origValue:   origValue,
+				fieldsValue: value,
 			},
 		}
 		a.init()
@@ -2036,8 +2038,8 @@ func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 					baseObject: baseObject{
 						val: obj,
 					},
-					origValue: origValue,
-					value:     value,
+					origValue:   origValue,
+					fieldsValue: value,
 				},
 			},
 		}
@@ -2054,8 +2056,8 @@ func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 		baseObject: baseObject{
 			val: obj,
 		},
-		origValue: origValue,
-		value:     value,
+		origValue:   origValue,
+		fieldsValue: value,
 	}
 	obj.self = o
 	o.init()

--- a/runtime.go
+++ b/runtime.go
@@ -2850,7 +2850,11 @@ func (r *Runtime) getIterator(obj Value, method func(FunctionCall) Value) *itera
 func (ir *iteratorRecord) iterate(step func(Value)) {
 	r := ir.iterator.runtime
 	for {
-		res := r.toObject(ir.next(FunctionCall{ctx: ir.ctx, This: ir.iterator}))
+		if ir.next == nil {
+			panic(r.NewTypeError("object null is not a function"))
+		}
+		nextVal := ir.next(FunctionCall{ctx: ir.ctx, This: ir.iterator})
+		res := r.toObject(nextVal)
 		if nilSafe(res.self.getStr("done", nil)).ToBoolean() {
 			break
 		}

--- a/runtime.go
+++ b/runtime.go
@@ -830,6 +830,30 @@ func (r *Runtime) newNativeFunc(call func(FunctionCall) Value, construct func(ar
 	return v
 }
 
+func (r *Runtime) newWrappedFunc(value reflect.Value) *Object {
+
+	v := &Object{runtime: r}
+
+	f := &wrappedFuncObject{
+		nativeFuncObject: nativeFuncObject{
+			baseFuncObject: baseFuncObject{
+				baseObject: baseObject{
+					class:      classFunction,
+					val:        v,
+					extensible: true,
+					prototype:  r.global.FunctionPrototype,
+				},
+			},
+			f: r.wrapReflectFunc(value),
+		},
+		wrapped: value,
+	}
+	v.self = f
+	name := unistring.NewFromString(runtime.FuncForPC(value.Pointer()).Name())
+	f.init(name, intToValue(int64(value.Type().NumIn())))
+	return v
+}
+
 func (r *Runtime) newNativeFuncConstructObj(v *Object, construct func(args []Value, proto *Object) *Object, name unistring.String, proto *Object, length int) *nativeFuncObject {
 	f := &nativeFuncObject{
 		ctx: r.vm.ctx,
@@ -2047,8 +2071,7 @@ func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 		obj.self = a
 		return obj
 	case reflect.Func:
-		name := unistring.NewFromString(runtime.FuncForPC(value.Pointer()).Name())
-		return r.newNativeFunc(r.wrapReflectFunc(value), nil, name, nil, value.Type().NumIn())
+		return r.newWrappedFunc(value)
 	}
 
 	obj := &Object{runtime: r}

--- a/runtime.go
+++ b/runtime.go
@@ -2361,10 +2361,11 @@ func (r *Runtime) wrapJSFunc(fn Callable, typ reflect.Type) func(args []reflect.
 			jsArgs[i] = r.ToValue(arg.Interface())
 		}
 
-		results = make([]reflect.Value, typ.NumOut())
+		numOut := typ.NumOut()
+		results = make([]reflect.Value, numOut)
 		res, err := fn(_undefined, jsArgs...)
 		if err == nil {
-			if typ.NumOut() > 0 {
+			if numOut > 0 {
 				v := reflect.New(typ.Out(0)).Elem()
 				err = r.toReflectValue(res, v, &objectExportCtx{})
 				if err == nil {
@@ -2374,8 +2375,17 @@ func (r *Runtime) wrapJSFunc(fn Callable, typ reflect.Type) func(args []reflect.
 		}
 
 		if err != nil {
-			if typ.NumOut() == 2 && typ.Out(1).Name() == "error" {
-				results[1] = reflect.ValueOf(err).Convert(typ.Out(1))
+			if numOut > 0 && typ.Out(numOut-1) == reflectTypeError {
+				if ex, ok := err.(*Exception); ok {
+					if exo, ok := ex.val.(*Object); ok {
+						if v := exo.self.getStr("value", nil); v != nil {
+							if v.ExportType().AssignableTo(reflectTypeError) {
+								err = v.Export().(error)
+							}
+						}
+					}
+				}
+				results[numOut-1] = reflect.ValueOf(err).Convert(typ.Out(numOut - 1))
 			} else {
 				panic(err)
 			}
@@ -2410,13 +2420,9 @@ func (r *Runtime) wrapJSFunc(fn Callable, typ reflect.Type) func(args []reflect.
 // Exporting to a 'func' creates a strictly typed 'gateway' into an ES function which can be called from Go.
 // The arguments are converted into ES values using Runtime.ToValue(). If the func has no return values,
 // the return value is ignored. If the func has exactly one return value, it is converted to the appropriate
-// type using ExportTo(). If the func has exactly 2 return values and the second value is 'error', exceptions
-// are caught and returned as *Exception. In all other cases exceptions result in a panic. Any extra return values
-// are zeroed.
-//
-// Note, if you want to catch and return exceptions as an `error` and you don't need the return value,
-// 'func(...) error' will not work as expected. The 'error' in this case is mapped to the function return value, not
-// the exception which will still result in a panic. Use 'func(...) (Value, error)' instead, and ignore the Value.
+// type using ExportTo(). If the last return value is 'error', exceptions are caught and returned as *Exception
+// (instances of GoError are unwrapped, i.e. their 'value' is returned instead). In all other cases exceptions
+// result in a panic. Any extra return values are zeroed.
 //
 // 'this' value will always be set to 'undefined'.
 //

--- a/runtime.go
+++ b/runtime.go
@@ -1733,27 +1733,27 @@ func(FunctionCall, *Runtime) Value is treated as above, except the *Runtime is a
 func(ConstructorCall) *Object is treated as a native constructor, allowing to use it with the new
 operator:
 
-		func MyObject(call goja.ConstructorCall) *goja.Object {
-		   // call.This contains the newly created object as per http://www.ecma-international.org/ecma-262/5.1/index.html#sec-13.2.2
-		   // call.Arguments contain arguments passed to the function
+	func MyObject(call goja.ConstructorCall) *goja.Object {
+	   // call.This contains the newly created object as per http://www.ecma-international.org/ecma-262/5.1/index.html#sec-13.2.2
+	   // call.Arguments contain arguments passed to the function
 
-		   call.This.Set("method", method)
+	   call.This.Set("method", method)
 
-		   //...
+	   //...
 
-	    // If return value is a non-nil *Object, it will be used instead of call.This
-	    // This way it is possible to return a Go struct or a map converted
-	    // into goja.Value using ToValue(), however in this case
-	    // instanceof will not work as expected, unless you set the prototype:
-	    //
-	    // instance := &myCustomStruct{}
-	    // instanceValue := vm.ToValue(instance).(*Object)
-	    // instanceValue.SetPrototype(call.This.Prototype())
-	    // return instanceValue
-	    return nil
-	 }
+	   // If return value is a non-nil *Object, it will be used instead of call.This
+	   // This way it is possible to return a Go struct or a map converted
+	   // into goja.Value using ToValue(), however in this case
+	   // instanceof will not work as expected, unless you set the prototype:
+	   //
+	   // instance := &myCustomStruct{}
+	   // instanceValue := vm.ToValue(instance).(*Object)
+	   // instanceValue.SetPrototype(call.This.Prototype())
+	   // return instanceValue
+	   return nil
+	}
 
-		runtime.Set("MyObject", MyObject)
+	runtime.Set("MyObject", MyObject)
 
 Then it can be used in JS as follows:
 

--- a/runtime.go
+++ b/runtime.go
@@ -1862,6 +1862,10 @@ Note that the underlying type is not lost, calling Export() returns the original
 reflect based types.
 */
 func (r *Runtime) ToValue(i interface{}) Value {
+	return r.toValue(i, reflect.Value{})
+}
+
+func (r *Runtime) toValue(i interface{}, origValue reflect.Value) Value {
 	switch i := i.(type) {
 	case nil:
 		return _null
@@ -1878,7 +1882,6 @@ func (r *Runtime) ToValue(i interface{}) Value {
 	case Value:
 		return i
 	case string:
-		// return newStringValue(i)
 		if len(i) <= 16 {
 			if u := unistring.Scan(i); u != nil {
 				return &importedString{s: i, u: u, scanned: true}
@@ -1964,9 +1967,6 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		m.init()
 		return obj
 	case []interface{}:
-		if i == nil {
-			return _null
-		}
 		return r.newObjectGoSlice(&i).val
 	case *[]interface{}:
 		if i == nil {
@@ -1975,10 +1975,10 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		return r.newObjectGoSlice(i).val
 	}
 
-	return r.reflectValueToValue(reflect.ValueOf(i))
-}
+	if !origValue.IsValid() {
+		origValue = reflect.ValueOf(i)
+	}
 
-func (r *Runtime) reflectValueToValue(origValue reflect.Value) Value {
 	value := origValue
 	for value.Kind() == reflect.Ptr {
 		value = value.Elem()

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2596,7 +2596,8 @@ func TestErrorStack(t *testing.T) {
 	if (Reflect.ownKeys(err)[0] !== "stack") {
 		throw new Error("property order");
 	}
-	if (err.stack !== "Error\n\tat test.js:2:14(3)\n") {
+	const stack = err.stack;
+	if (stack !== "Error: test\n\tat test.js:2:14(3)\n") {
 		throw new Error(stack);
 	}
 	delete err.stack;

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1036,7 +1036,7 @@ func TestToValueNil(t *testing.T) {
 	}
 
 	var ar []interface{}
-	if v := vm.ToValue(ar); !IsNull(v) {
+	if v := vm.ToValue(ar); IsNull(v) {
 		t.Fatalf("[]interface{}: %v", v)
 	}
 

--- a/string.go
+++ b/string.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"unicode/utf16"
 	"unicode/utf8"
 
 	"github.com/dop251/goja/unistring"
@@ -53,8 +52,8 @@ type valueString interface {
 	concat(valueString) valueString
 	substring(start, end int) valueString
 	compareTo(valueString) int
-	reader(start int) io.RuneReader
-	utf16Reader(start int) io.RuneReader
+	reader() io.RuneReader
+	utf16Reader() io.RuneReader
 	utf16Runes() []rune
 	index(valueString, int) int
 	lastIndex(valueString, int) int
@@ -91,16 +90,10 @@ func (si *stringIterObject) next() Value {
 func stringFromRune(r rune) valueString {
 	if r < utf8.RuneSelf {
 		var sb strings.Builder
-		sb.Grow(1)
 		sb.WriteByte(byte(r))
 		return asciiString(sb.String())
 	}
 	var sb unicodeStringBuilder
-	if r <= 0xFFFF {
-		sb.Grow(1)
-	} else {
-		sb.Grow(2)
-	}
 	sb.WriteRune(r)
 	return sb.String()
 }
@@ -109,7 +102,7 @@ func (r *Runtime) createStringIterator(s valueString) Value {
 	o := &Object{runtime: r}
 
 	si := &stringIterObject{
-		reader: &lenientUtf16Decoder{utf16Reader: s.utf16Reader(0)},
+		reader: &lenientUtf16Decoder{utf16Reader: s.utf16Reader()},
 	}
 	si.class = classStringIterator
 	si.val = o
@@ -129,35 +122,10 @@ type stringObject struct {
 }
 
 func newStringValue(s string) valueString {
-	utf16Size := 0
-	ascii := true
-	for _, chr := range s {
-		utf16Size++
-		if chr >= utf8.RuneSelf {
-			ascii = false
-			if chr > 0xFFFF {
-				utf16Size++
-			}
-		}
+	if u := unistring.Scan(s); u != nil {
+		return unicodeString(u)
 	}
-	if ascii {
-		return asciiString(s)
-	}
-	buf := make([]uint16, utf16Size+1)
-	buf[0] = unistring.BOM
-	c := 1
-	for _, chr := range s {
-		if chr <= 0xFFFF {
-			buf[c] = uint16(chr)
-		} else {
-			first, second := utf16.EncodeRune(chr)
-			buf[c] = uint16(first)
-			c++
-			buf[c] = uint16(second)
-		}
-		c++
-	}
-	return unicodeString(buf)
+	return asciiString(s)
 }
 
 func stringValueFromRaw(raw unistring.String) valueString {
@@ -337,6 +305,27 @@ func (s *stringObject) hasOwnPropertyIdx(idx valueInt) bool {
 		return true
 	}
 	return s.baseObject.hasOwnPropertyStr(idx.string())
+}
+
+func devirtualizeString(s valueString) (asciiString, unicodeString) {
+	switch s := s.(type) {
+	case asciiString:
+		return s, nil
+	case unicodeString:
+		return "", s
+	case *importedString:
+		s.ensureScanned()
+		if s.u != nil {
+			return "", s.u
+		}
+		return asciiString(s.s), nil
+	default:
+		panic(unknownStringTypeErr(s))
+	}
+}
+
+func unknownStringTypeErr(v Value) interface{} {
+	return newTypeError("Internal bug: unknown string type: %T", v)
 }
 
 func (s *stringObject) MemUsage(ctx *MemUsageContext) (uint64, error) {

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -1,7 +1,6 @@
 package goja
 
 import (
-	"fmt"
 	"hash/maphash"
 	"io"
 	"math"
@@ -30,14 +29,14 @@ func (rr *asciiRuneReader) ReadRune() (r rune, size int, err error) {
 	return
 }
 
-func (s asciiString) reader(start int) io.RuneReader {
+func (s asciiString) reader() io.RuneReader {
 	return &asciiRuneReader{
-		s: s[start:],
+		s: s,
 	}
 }
 
-func (s asciiString) utf16Reader(start int) io.RuneReader {
-	return s.reader(start)
+func (s asciiString) utf16Reader() io.RuneReader {
+	return s.reader()
 }
 
 func (s asciiString) utf16Runes() []rune {
@@ -180,15 +179,12 @@ func (s asciiString) ToObject(r *Runtime) *Object {
 }
 
 func (s asciiString) SameAs(other Value) bool {
-	if otherStr, ok := other.(asciiString); ok {
-		return s == otherStr
-	}
-	return false
+	return s.StrictEquals(other)
 }
 
 func (s asciiString) Equals(other Value) bool {
-	if o, ok := other.(asciiString); ok {
-		return s == o
+	if s.StrictEquals(other) {
+		return true
 	}
 
 	if o, ok := other.(valueInt); ok {
@@ -225,6 +221,11 @@ func (s asciiString) StrictEquals(other Value) bool {
 	if otherStr, ok := other.(asciiString); ok {
 		return s == otherStr
 	}
+	if otherStr, ok := other.(*importedString); ok {
+		if otherStr.u == nil {
+			return string(s) == otherStr.s
+		}
+	}
 	return false
 }
 
@@ -251,20 +252,17 @@ func (s asciiString) length() int {
 }
 
 func (s asciiString) concat(other valueString) valueString {
-	switch other := other.(type) {
-	case asciiString:
-		return asciiString(s + other)
-	case unicodeString:
-		b := make([]uint16, len(s)+len(other))
+	a, u := devirtualizeString(other)
+	if u != nil {
+		b := make([]uint16, len(s)+len(u))
 		b[0] = unistring.BOM
 		for i := 0; i < len(s); i++ {
 			b[i+1] = uint16(s[i])
 		}
-		copy(b[len(s)+1:], other[1:])
+		copy(b[len(s)+1:], u[1:])
 		return unicodeString(b)
-	default:
-		panic(fmt.Errorf("unknown string type: %T", other))
 	}
+	return s + a
 }
 
 func (s asciiString) substring(start, end int) valueString {
@@ -277,14 +275,17 @@ func (s asciiString) compareTo(other valueString) int {
 		return strings.Compare(string(s), string(other))
 	case unicodeString:
 		return strings.Compare(string(s), other.String())
+	case *importedString:
+		return strings.Compare(string(s), other.s)
 	default:
-		panic(fmt.Errorf("unknown string type: %T", other))
+		panic(newTypeError("Internal bug: unknown string type: %T", other))
 	}
 }
 
 func (s asciiString) index(substr valueString, start int) int {
-	if substr, ok := substr.(asciiString); ok {
-		p := strings.Index(string(s[start:]), string(substr))
+	a, u := devirtualizeString(substr)
+	if u == nil {
+		p := strings.Index(string(s[start:]), string(a))
 		if p >= 0 {
 			return p + start
 		}
@@ -293,15 +294,16 @@ func (s asciiString) index(substr valueString, start int) int {
 }
 
 func (s asciiString) lastIndex(substr valueString, pos int) int {
-	if substr, ok := substr.(asciiString); ok {
-		end := pos + len(substr)
+	a, u := devirtualizeString(substr)
+	if u == nil {
+		end := pos + len(a)
 		var ss string
 		if end > len(s) {
 			ss = string(s)
 		} else {
 			ss = string(s[:end])
 		}
-		return strings.LastIndex(ss, string(substr))
+		return strings.LastIndex(ss, string(a))
 	}
 	return -1
 }

--- a/string_imported.go
+++ b/string_imported.go
@@ -196,6 +196,10 @@ func (i *importedString) ExportType() reflect.Type {
 }
 
 func (i *importedString) baseObject(r *Runtime) *Object {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.baseObject(r)
+	}
 	return asciiString(i.s).baseObject(r)
 }
 

--- a/string_imported.go
+++ b/string_imported.go
@@ -1,0 +1,351 @@
+package goja
+
+import (
+	"hash/maphash"
+	"io"
+	"math"
+	"reflect"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"github.com/dop251/goja/parser"
+	"github.com/dop251/goja/unistring"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// Represents a string imported from Go. The idea is to delay the scanning for unicode characters and converting
+// to unicodeString until necessary. This way strings that are merely passed through never get scanned which
+// saves CPU and memory.
+// Currently, importedString is created in 2 cases: Runtime.ToValue() for strings longer than 16 bytes and as a result
+// of JSON.stringify() if it may contain unicode characters. More cases could be added in the future.
+type importedString struct {
+	s string
+	u unicodeString
+
+	scanned bool
+}
+
+func (i *importedString) scan() {
+	i.u = unistring.Scan(i.s)
+	i.scanned = true
+}
+
+func (i *importedString) ensureScanned() {
+	if !i.scanned {
+		i.scan()
+	}
+}
+
+func (i *importedString) ToInteger() int64 {
+	i.ensureScanned()
+	if i.u != nil {
+		return 0
+	}
+	return asciiString(i.s).ToInteger()
+}
+
+func (i *importedString) toString() valueString {
+	return i
+}
+
+func (i *importedString) string() unistring.String {
+	i.ensureScanned()
+	if i.u != nil {
+		return unistring.FromUtf16(i.u)
+	}
+	return unistring.String(i.s)
+}
+
+func (i *importedString) ToString() Value {
+	return i
+}
+
+func (i *importedString) String() string {
+	return i.s
+}
+
+func (i *importedString) ToFloat() float64 {
+	i.ensureScanned()
+	if i.u != nil {
+		return math.NaN()
+	}
+	return asciiString(i.s).ToFloat()
+}
+
+func (i *importedString) ToNumber() Value {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.ToNumber()
+	}
+	return asciiString(i.s).ToNumber()
+}
+
+func (i *importedString) ToBoolean() bool {
+	return len(i.s) != 0
+}
+
+func (i *importedString) ToObject(r *Runtime) *Object {
+	return r._newString(i, r.global.StringPrototype)
+}
+
+func (i *importedString) ToInt() int {
+	i.ensureScanned()
+	if i.u != nil {
+		return 0
+	}
+	return asciiString(i.s).ToInt()
+}
+
+func (i *importedString) ToInt32() int32 {
+	i.ensureScanned()
+	if i.u != nil {
+		return 0
+	}
+	return asciiString(i.s).ToInt32()
+}
+
+func (i *importedString) ToUInt32() uint32 {
+	i.ensureScanned()
+	if i.u != nil {
+		return 0
+	}
+	return asciiString(i.s).ToUInt32()
+}
+
+func (i *importedString) ToInt64() int64 {
+	i.ensureScanned()
+	if i.u != nil {
+		return 0
+	}
+	return asciiString(i.s).ToInt64()
+}
+
+func (i *importedString) IsObject() bool {
+	return false
+}
+
+func (i *importedString) IsNumber() bool {
+	return false
+}
+
+func (i *importedString) assertInt() (int, bool) {
+	return 0, false
+}
+
+func (i *importedString) assertUInt32() (uint32, bool) {
+	return 0, false
+}
+
+func (i *importedString) assertInt32() (int32, bool) {
+	return 0, false
+}
+
+func (i *importedString) assertInt64() (int64, bool) {
+	return 0, false
+}
+
+func (i *importedString) assertFloat() (float64, bool) {
+	return 0, false
+}
+
+func (i *importedString) assertString() (valueString, bool) {
+	return i.toString(), true
+}
+func (i *importedString) SameAs(other Value) bool {
+	return i.StrictEquals(other)
+}
+
+func (i *importedString) Equals(other Value) bool {
+	if i.StrictEquals(other) {
+		return true
+	}
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.Equals(other)
+	}
+	return asciiString(i.s).Equals(other)
+}
+
+func (i *importedString) StrictEquals(other Value) bool {
+	switch otherStr := other.(type) {
+	case asciiString:
+		if i.u != nil {
+			return false
+		}
+		return i.s == string(otherStr)
+	case unicodeString:
+		i.ensureScanned()
+		if i.u != nil && i.u.equals(otherStr) {
+			return true
+		}
+	case *importedString:
+		return i.s == otherStr.s
+	}
+	return false
+}
+
+func (i *importedString) Export() interface{} {
+	return i.s
+}
+
+func (i *importedString) ExportType() reflect.Type {
+	return reflectTypeString
+}
+
+func (i *importedString) baseObject(r *Runtime) *Object {
+	return asciiString(i.s).baseObject(r)
+}
+
+func (i *importedString) hash(hasher *maphash.Hash) uint64 {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.hash(hasher)
+	}
+	return asciiString(i.s).hash(hasher)
+}
+
+func (i *importedString) charAt(idx int) rune {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.charAt(idx)
+	}
+	return asciiString(i.s).charAt(idx)
+}
+
+func (i *importedString) length() int {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.length()
+	}
+	return asciiString(i.s).length()
+}
+
+func (i *importedString) concat(v valueString) valueString {
+	if !i.scanned {
+		if v, ok := v.(*importedString); ok {
+			if !v.scanned {
+				return &importedString{s: i.s + v.s}
+			}
+		}
+		i.ensureScanned()
+	}
+	if i.u != nil {
+		return i.u.concat(v)
+	}
+	return asciiString(i.s).concat(v)
+}
+
+func (i *importedString) substring(start, end int) valueString {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.substring(start, end)
+	}
+	return asciiString(i.s).substring(start, end)
+}
+
+func (i *importedString) compareTo(v valueString) int {
+	return strings.Compare(i.s, v.String())
+}
+
+func (i *importedString) reader() io.RuneReader {
+	if i.scanned {
+		if i.u != nil {
+			return i.u.reader()
+		}
+		return asciiString(i.s).reader()
+	}
+	return strings.NewReader(i.s)
+}
+
+type stringUtf16Reader struct {
+	s      string
+	pos    int
+	second rune
+}
+
+func (s *stringUtf16Reader) ReadRune() (r rune, size int, err error) {
+	if s.second >= 0 {
+		r = s.second
+		s.second = -1
+		size = 1
+		return
+	}
+	if s.pos < len(s.s) {
+		r1, size1 := utf8.DecodeRuneInString(s.s[s.pos:])
+		s.pos += size1
+		size = 1
+		if r1 <= 0xFFFF {
+			r = r1
+		} else {
+			r, s.second = utf16.EncodeRune(r1)
+		}
+	} else {
+		err = io.EOF
+	}
+	return
+}
+
+func (i *importedString) utf16Reader() io.RuneReader {
+	if i.scanned {
+		if i.u != nil {
+			return i.u.utf16Reader()
+		}
+		return asciiString(i.s).utf16Reader()
+	}
+	return &stringUtf16Reader{
+		s:      i.s,
+		second: -1,
+	}
+}
+
+func (i *importedString) utf16Runes() []rune {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.utf16Runes()
+	}
+	return asciiString(i.s).utf16Runes()
+}
+
+func (i *importedString) index(v valueString, start int) int {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.index(v, start)
+	}
+	return asciiString(i.s).index(v, start)
+}
+
+func (i *importedString) lastIndex(v valueString, pos int) int {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.lastIndex(v, pos)
+	}
+	return asciiString(i.s).lastIndex(v, pos)
+}
+
+func (i *importedString) toLower() valueString {
+	i.ensureScanned()
+	if i.u != nil {
+		return toLower(i.s)
+	}
+	return asciiString(i.s).toLower()
+}
+
+func (i *importedString) toUpper() valueString {
+	i.ensureScanned()
+	if i.u != nil {
+		caser := cases.Upper(language.Und)
+		return newStringValue(caser.String(i.s))
+	}
+	return asciiString(i.s).toUpper()
+}
+
+func (i *importedString) toTrimmedUTF8() string {
+	return strings.Trim(i.s, parser.WhitespaceChars)
+}
+
+func (i *importedString) MemUsage(ctx *MemUsageContext) (uint64, error) {
+	return uint64(len(i.String())), nil
+}

--- a/string_test.go
+++ b/string_test.go
@@ -1,6 +1,10 @@
 package goja
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
 
 func TestStringOOBProperties(t *testing.T) {
 	const SCRIPT = `
@@ -11,6 +15,137 @@ func TestStringOOBProperties(t *testing.T) {
 	`
 
 	testScript(SCRIPT, valueInt(1), t)
+}
+
+func TestImportedString(t *testing.T) {
+	vm := New()
+
+	testUnaryOp := func(a, expr string, result interface{}, t *testing.T) {
+		v, err := vm.RunString("a => " + expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fn func(a Value) (Value, error)
+		err = vm.ExportTo(v, &fn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, aa := range []Value{newStringValue(a), vm.ToValue(a)} {
+			res, err := fn(aa)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.Export() != result {
+				t.Fatalf("%s, a:%v(%T). expected: %v, actual: %v", expr, aa, aa, result, res)
+			}
+		}
+	}
+
+	testBinaryOp := func(a, b, expr string, result interface{}, t *testing.T) {
+		v, err := vm.RunString("(a, b) => " + expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fn func(a, b Value) (Value, error)
+		err = vm.ExportTo(v, &fn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, aa := range []Value{newStringValue(a), vm.ToValue(a)} {
+			for _, bb := range []Value{newStringValue(b), vm.ToValue(b)} {
+				res, err := fn(aa, bb)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if res.Export() != result {
+					t.Fatalf("%s, a:%v(%T), b:%v(%T). expected: %v, actual: %v", expr, aa, aa, bb, bb, result, res)
+				}
+			}
+		}
+	}
+
+	strs := []string{"shortAscii", "longlongAscii1234567890123456789", "short юникод", "long юникод 1234567890 юникод \U0001F600", "юникод", "Ascii", "long", "код"}
+	indexOfResults := [][]int{
+		/*
+			const strs = ["shortAscii", "longlongAscii1234567890123456789", "short юникод", "long юникод 1234567890 юникод \u{1F600}", "юникод", "Ascii", "long", "код"];
+
+			strs.forEach(a => {
+			    console.log("{", strs.map(b => a.indexOf(b)).join(", "), "},");
+			});
+		*/
+		{0, -1, -1, -1, -1, 5, -1, -1},
+		{-1, 0, -1, -1, -1, 8, 0, -1},
+		{-1, -1, 0, -1, 6, -1, -1, 9},
+		{-1, -1, -1, 0, 5, -1, 0, 8},
+		{-1, -1, -1, -1, 0, -1, -1, 3},
+		{-1, -1, -1, -1, -1, 0, -1, -1},
+		{-1, -1, -1, -1, -1, -1, 0, -1},
+		{-1, -1, -1, -1, -1, -1, -1, 0},
+	}
+
+	lastIndexOfResults := [][]int{
+		/*
+			strs.forEach(a => {
+			    console.log("{", strs.map(b => a.lastIndexOf(b)).join(", "), "},");
+			});
+		*/
+		{0, -1, -1, -1, -1, 5, -1, -1},
+		{-1, 0, -1, -1, -1, 8, 4, -1},
+		{-1, -1, 0, -1, 6, -1, -1, 9},
+		{-1, -1, -1, 0, 23, -1, 0, 26},
+		{-1, -1, -1, -1, 0, -1, -1, 3},
+		{-1, -1, -1, -1, -1, 0, -1, -1},
+		{-1, -1, -1, -1, -1, -1, 0, -1},
+		{-1, -1, -1, -1, -1, -1, -1, 0},
+	}
+
+	pad := func(s, p string, n int, start bool) string {
+		if n == 0 {
+			return s
+		}
+		if p == "" {
+			p = " "
+		}
+		var b strings.Builder
+		ss := utf16.Encode([]rune(s))
+		b.Grow(n)
+		n -= len(ss)
+		if !start {
+			b.WriteString(s)
+		}
+		if n > 0 {
+			pp := utf16.Encode([]rune(p))
+			for n > 0 {
+				if n > len(pp) {
+					b.WriteString(p)
+					n -= len(pp)
+				} else {
+					b.WriteString(string(utf16.Decode(pp[:n])))
+					n = 0
+				}
+			}
+		}
+		if start {
+			b.WriteString(s)
+		}
+		return b.String()
+	}
+
+	for i, a := range strs {
+		testUnaryOp(a, "JSON.parse(JSON.stringify(a))", a, t)
+		for j, b := range strs {
+			testBinaryOp(a, b, "a === b", a == b, t)
+			testBinaryOp(a, b, "a == b", a == b, t)
+			testBinaryOp(a, b, "a + b", a+b, t)
+			testBinaryOp(a, b, "a > b", strings.Compare(a, b) > 0, t)
+			testBinaryOp(a, b, "`A${a}B${b}C`", "A"+a+"B"+b+"C", t)
+			testBinaryOp(a, b, "a.indexOf(b)", int64(indexOfResults[i][j]), t)
+			testBinaryOp(a, b, "a.lastIndexOf(b)", int64(lastIndexOfResults[i][j]), t)
+			testBinaryOp(a, b, "a.padStart(32, b)", pad(a, b, 32, true), t)
+			testBinaryOp(a, b, "a.padEnd(32, b)", pad(a, b, 32, false), t)
+			testBinaryOp(a, b, "a.replace(b, '')", strings.Replace(a, b, "", 1), t)
+		}
+	}
 }
 
 func BenchmarkASCIIConcat(b *testing.B) {

--- a/string_test.go
+++ b/string_test.go
@@ -133,6 +133,7 @@ func TestImportedString(t *testing.T) {
 
 	for i, a := range strs {
 		testUnaryOp(a, "JSON.parse(JSON.stringify(a))", a, t)
+		testUnaryOp(a, "a.length", int64(len(utf16.Encode([]rune(a)))), t)
 		for j, b := range strs {
 			testBinaryOp(a, b, "a === b", a == b, t)
 			testBinaryOp(a, b, "a == b", a == b, t)

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -265,7 +265,6 @@ var (
 		"generators",
 		"String.prototype.replaceAll",
 		"resizable-arraybuffer",
-		"array-find-from-last",
 		"regexp-named-groups",
 		"regexp-dotall",
 		"regexp-unicode-property-escapes",

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -303,9 +303,7 @@ func init() {
 	}
 
 	skip(
-		// Go 1.14 only supports unicode 12
-		"test/language/identifiers/start-unicode-13.",
-		"test/language/identifiers/part-unicode-13.",
+		// Go 1.16 only supports unicode 13
 		"test/language/identifiers/start-unicode-14.",
 		"test/language/identifiers/part-unicode-14.",
 

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -281,8 +281,6 @@ var (
 		"FinalizationRegistry",
 		"WeakRef",
 		"numeric-separator-literal",
-		"Object.fromEntries",
-		"Object.hasOwn",
 		"__getter__",
 		"__setter__",
 		"ShadowRealm",

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -220,6 +220,7 @@ var (
 		"test/language/statements/class/elements/private-async-method-name.js":                                                         true,
 		"test/language/expressions/in/private-field-rhs-await-present.js":                                                              true,
 		"test/language/expressions/class/elements/private-static-async-method-name.js":                                                 true,
+		"test/language/comments/hashbang/function-constructor.js":                                                                      true,
 
 		// legacy number literals
 		"test/language/literals/numeric/non-octal-decimal-integer.js": true,
@@ -290,7 +291,6 @@ var (
 		"error-cause",
 		"decorators",
 		"regexp-v-flag",
-		"hashbang",
 	}
 )
 

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -3,7 +3,7 @@ package goja
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"sort"
@@ -413,7 +413,7 @@ func parseTC39File(name string) (*tc39Meta, string, error) {
 	}
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, "", err
 	}
@@ -637,7 +637,7 @@ func (ctx *tc39TestCtx) compile(base, name string) (*Program, error) {
 		}
 		defer f.Close()
 
-		b, err := ioutil.ReadAll(f)
+		b, err := io.ReadAll(f)
 		if err != nil {
 			return nil, err
 		}
@@ -695,7 +695,7 @@ func (ctx *tc39TestCtx) runTC39Script(name, src string, includes []string, vm *R
 }
 
 func (ctx *tc39TestCtx) runTC39Tests(name string) {
-	files, err := ioutil.ReadDir(path.Join(ctx.base, name))
+	files, err := os.ReadDir(path.Join(ctx.base, name))
 	if err != nil {
 		ctx.t.Fatal(err)
 	}

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -30,6 +30,54 @@ var (
 
 	skipList = map[string]bool{
 
+		// out-of-date (https://github.com/tc39/test262/issues/3407)
+		"test/language/expressions/prefix-increment/S11.4.4_A6_T3.js":        true,
+		"test/language/expressions/prefix-increment/S11.4.4_A6_T2.js":        true,
+		"test/language/expressions/prefix-increment/S11.4.4_A6_T1.js":        true,
+		"test/language/expressions/prefix-decrement/S11.4.5_A6_T3.js":        true,
+		"test/language/expressions/prefix-decrement/S11.4.5_A6_T2.js":        true,
+		"test/language/expressions/prefix-decrement/S11.4.5_A6_T1.js":        true,
+		"test/language/expressions/postfix-increment/S11.3.1_A6_T3.js":       true,
+		"test/language/expressions/postfix-increment/S11.3.1_A6_T2.js":       true,
+		"test/language/expressions/postfix-increment/S11.3.1_A6_T1.js":       true,
+		"test/language/expressions/postfix-decrement/S11.3.2_A6_T3.js":       true,
+		"test/language/expressions/postfix-decrement/S11.3.2_A6_T2.js":       true,
+		"test/language/expressions/postfix-decrement/S11.3.2_A6_T1.js":       true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.1_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.1_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.1_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.11_T4.js": true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.11_T2.js": true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.11_T1.js": true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.10_T4.js": true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.10_T2.js": true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.10_T1.js": true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.9_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.9_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.9_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.8_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.8_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.8_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.7_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.7_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.7_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.6_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.6_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.6_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.5_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.5_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.5_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.4_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.4_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.4_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.3_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.3_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.3_T1.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.2_T4.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.2_T2.js":  true,
+		"test/language/expressions/compound-assignment/S11.13.2_A7.2_T1.js":  true,
+		"test/language/expressions/assignment/S11.13.1_A7_T3.js":             true,
+
 		// timezone
 		"test/built-ins/Date/prototype/toISOString/15.9.5.43-0-8.js":  true,
 		"test/built-ins/Date/prototype/toISOString/15.9.5.43-0-9.js":  true,
@@ -570,10 +618,6 @@ func (ctx *tc39TestCtx) runTC39File(name string, t testing.TB) {
 		t.Skip("module")
 	}
 	if meta.Es5id == "" {
-		if meta.Es6id == "" && meta.Esid == "" {
-			t.Skip("No ids")
-		}
-
 		for _, feature := range meta.Features {
 			for _, bl := range featuresBlackList {
 				if feature == bl {

--- a/value.go
+++ b/value.go
@@ -1360,8 +1360,20 @@ func (o *Object) MarshalJSON() ([]byte, error) {
 	return ctx.buf.Bytes(), nil
 }
 
-// Class returns the class name
+// UnmarshalJSON implements the json.Unmarshaler interface. It is added to compliment MarshalJSON, because
+// some alternative JSON encoders refuse to use MarshalJSON unless UnmarshalJSON is also present.
+// It is a no-op and always returns nil.
+func (o *Object) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+// Class returns the class name (otto compatibility)
 func (o *Object) Class() string {
+	return o.self.className()
+}
+
+// ClassName returns the class name
+func (o *Object) ClassName() string {
 	return o.self.className()
 }
 

--- a/value.go
+++ b/value.go
@@ -54,6 +54,7 @@ var (
 	reflectTypeArray  = reflect.TypeOf([]interface{}{})
 	reflectTypeString = reflect.TypeOf("")
 	reflectTypeFunc   = reflect.TypeOf((func(FunctionCall) Value)(nil))
+	reflectTypeError  = reflect.TypeOf((*error)(nil)).Elem()
 )
 
 var intCache [256]Value

--- a/vm.go
+++ b/vm.go
@@ -4862,13 +4862,26 @@ func (n concatStrings) exec(vm *vm) {
 	strs := vm.stack[vm.sp-int(n) : vm.sp]
 	length := 0
 	allAscii := true
-	for _, s := range strs {
-		if allAscii {
-			if _, ok := s.(unicodeString); ok {
+	for i, s := range strs {
+		switch s := s.(type) {
+		case asciiString:
+			length += s.length()
+		case unicodeString:
+			length += s.length()
+			allAscii = false
+		case *importedString:
+			s.ensureScanned()
+			if s.u != nil {
+				strs[i] = s.u
+				length += s.u.length()
 				allAscii = false
+			} else {
+				strs[i] = asciiString(s.s)
+				length += len(s.s)
 			}
+		default:
+			panic(unknownStringTypeErr(s))
 		}
-		length += s.(valueString).length()
 	}
 
 	vm.sp -= int(n) - 1

--- a/vm.go
+++ b/vm.go
@@ -3364,6 +3364,8 @@ repeat:
 		return
 	case *nativeFuncObject:
 		vm._nativeCall(f, n)
+	case *wrappedFuncObject:
+		vm._nativeCall(&f.nativeFuncObject, n)
 	case *boundFuncObject:
 		vm._nativeCall(&f.nativeFuncObject, n)
 	case *proxyObject:
@@ -4515,7 +4517,7 @@ func (_typeof) exec(vm *vm) {
 			break
 		}
 		switch s := v.self.(type) {
-		case *classFuncObject, *methodFuncObject, *funcObject, *nativeFuncObject, *boundFuncObject, *arrowFuncObject:
+		case *classFuncObject, *methodFuncObject, *funcObject, *nativeFuncObject, *wrappedFuncObject, *boundFuncObject, *arrowFuncObject:
 			r = stringFunction
 		case *proxyObject:
 			if s.call == nil {


### PR DESCRIPTION
## Conflicts

### [Optimized CPU and memory usage when importing strings and using JSON](https://github.com/mongodb-forks/goja/pull/81/commits/350e5e3bc02d95668814547ec89604a490590aa3)

* This introduced `string_imported.go` which required to add a few methods that were missing to implement the `Value` interface including:
  * `ToInt`, `ToInt32`, `ToUint32`, `ToInto64`, `IsNumber`, `assertInt`,`assertUInt32`,`assertInt32`,`assertInt64`,`assertFloat`,`assertString`, `MemUsage`

### [Fixed formatting for Go 1.19](https://github.com/mongodb-forks/goja/pull/82/commits/40e3b0ca51808c1402ffded0938bedee4da22bf2)
* The promise file stayed deleted since we don’t support them


### [Removed the usage of deprecated ioutil package. Bumped minimum Go version to 1.16.](https://github.com/mongodb-forks/goja/pull/82/commits/186534a965d848295a613c8851702ce45c058726)

* Updated the evg file to use 1.16

### [Squashed commit of the following:](https://github.com/mongodb-forks/goja/pull/82/commits/2ed2a5b9ab1889a56aa737405884ca88b6fd366a)
(Unfortunate commit name from goja)

* Added `ctx` in `iterate` function in `runtime.go:2856`
* Removed legacy `object_fromEntries` since it's now duplicate.

### [Do not fail getIterator if 'next' is set, but not a function, only fail in iterator step, as per the specification. Adjusted the error message.](https://github.com/mongodb-forks/goja/pull/82/commits/a8b7a772523b1e19cd0e7cc45770a3a082ebbc80)
* Same as the above in `runtime.go` adding `ctx` to `FunctionCall`.

### [Fixed the order in which the adder function and the iterator are obtained in {Weak}{Set,Map} constructors.](https://github.com/mongodb-forks/goja/pull/82/commits/4996913cb043a0e0ea8d1d00712789f180946d30)
* Added `ctx` to `builtin_set.go:230+234`

## BAAS

Evergreen in progress [here](https://spruce.mongodb.com/version/6421be1f9ccd4e591a56f8f3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). One goja test is failing but I just need to update it over there, everything else looks good!