### PR TITLE
BAAS-19940: return type error when value is not a constructor

### DIFF
--- a/builtin_reflect.go
+++ b/builtin_reflect.go
@@ -12,7 +12,7 @@ func (r *Runtime) toConstructor(v Value) func(args []Value, newTarget *Object) *
 		return ctor
 	}
 
-	panic("Value is not a constructor")
+	panic(r.NewTypeError("Value is not a constructor"))
 }
 
 func (r *Runtime) builtin_reflect_construct(call FunctionCall) Value {


### PR DESCRIPTION
I think it would be nice if it logged the actual value name like Node does but I won't make that change and stay consistent for now.