### PR TITLE
BAAS-21844: estimate mem usage for large objects

### DIFF
--- a/array.go
+++ b/array.go
@@ -563,22 +563,22 @@ var (
 // With this function we sample 10% of the array values,
 // determine their average mem usage and use that to estimate mem
 // usage of the whole array
-func estimateMemUsage(ctx *MemUsageContext, values []Value) (uint64, error) {
+func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 	var total, samplesVisited, runningEstimate uint64
-	sampleSize := len(values) / 10
+	sampleSize := len(a.values) / 10
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions
-	for i := 0; i < len(values); i += sampleSize {
-		if values[i] == nil {
+	for i := 0; i < len(a.values); i += sampleSize {
+		if a.values[i] == nil {
 			continue
 		}
 
-		inc, err := values[i].MemUsage(ctx)
+		inc, err := a.values[i].MemUsage(ctx)
 		samplesVisited += 1
 		total += inc
-		// average * number of values
-		runningEstimate = uint64((float32(total) / float32(samplesVisited)) * float32(len(values)))
+		// average * number of a.values
+		runningEstimate = uint64((float32(total) / float32(samplesVisited)) * float32(len(a.values)))
 		if err != nil {
 			return runningEstimate, err
 		}
@@ -614,7 +614,7 @@ func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 		return total, errArrayLenExceedsThresholdNil
 	}
 	if ctx.ArrayLenExceedsThreshold(len(a.values)) {
-		inc, err := estimateMemUsage(ctx, a.values)
+		inc, err := a.estimateMemUsage(ctx)
 		total += inc
 		if err != nil {
 			return total, err

--- a/mem_context.go
+++ b/mem_context.go
@@ -91,11 +91,18 @@ type MemUsageContext struct {
 	visitTracker
 	*depthTracker
 	NativeMemUsageChecker
-	MemUsageExceedsLimit     func(memUsage uint64) bool
-	ArrayLenExceedsThreshold func(arrayLen int) bool
+	MemUsageExceedsLimit           func(memUsage uint64) bool
+	ArrayLenExceedsThreshold       func(arrayLen int) bool
+	ObjectPropsLenExceedsThreshold func(objPropsLen int) bool
 }
 
-func NewMemUsageContext(vm *Runtime, maxDepth int, memLimit uint64, arrayLenThreshold int, nativeChecker NativeMemUsageChecker) *MemUsageContext {
+func NewMemUsageContext(
+	vm *Runtime,
+	maxDepth int,
+	memLimit uint64,
+	arrayLenThreshold, objPropsLenThreshold int,
+	nativeChecker NativeMemUsageChecker,
+) *MemUsageContext {
 	return &MemUsageContext{
 		visitTracker:          visitTracker{objsVisited: map[objectImpl]bool{}, stashesVisited: map[*stash]bool{}},
 		depthTracker:          &depthTracker{curDepth: 0, maxDepth: maxDepth},
@@ -107,6 +114,10 @@ func NewMemUsageContext(vm *Runtime, maxDepth int, memLimit uint64, arrayLenThre
 		ArrayLenExceedsThreshold: func(arrayLen int) bool {
 			// array length threshold above which we should estimate mem usage
 			return arrayLen > arrayLenThreshold
+		},
+		ObjectPropsLenExceedsThreshold: func(objPropsLen int) bool {
+			// number of obj props beyond which we should estimate mem usage
+			return objPropsLen > objPropsLenThreshold
 		},
 	}
 }

--- a/object.go
+++ b/object.go
@@ -1925,11 +1925,9 @@ func (i *privateId) string() unistring.String {
 	return privateIdString(i.name)
 }
 
-// for very large objects calculating mem usage on each key/value pair
-// becomes expensive both in terms of memory used by the host to compute it
-// and timeout. With this function we grab a sample of 10% items to
-// determine their average mem usage and use that to estimate mem
-// usage of the whole object
+// estimateMemUsage helps calculating mem usage for large objects.
+// It will sample the object and use those samples to estimate the
+// mem usage.
 func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 	var total, samplesVisited uint64
 	var averageMemUsage float32

--- a/object.go
+++ b/object.go
@@ -1945,8 +1945,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 		inc, err := v.MemUsage(ctx)
 		samplesVisited += 1
 		total += inc
-		kMem := uint64(len(k))
-		total += kMem
+		total += uint64(len(k))
 		averageMemUsage = float32(total) / float32(samplesVisited)
 		if err != nil {
 			return uint64(averageMemUsage * float32(len(o.propNames))), err

--- a/object.go
+++ b/object.go
@@ -1925,6 +1925,39 @@ func (i *privateId) string() unistring.String {
 	return privateIdString(i.name)
 }
 
+// for very large objects calculating mem usage on each key/value pair
+// becomes expensive both in terms of memory used by the host to compute it
+// and timeout. With this function we grab a sample of 10% items to
+// determine their average mem usage and use that to estimate mem
+// usage of the whole object
+func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
+	var total, samplesVisited uint64
+	var averageMemUsage float32
+	sampleSize := len(o.propNames) / 10
+
+	// grabbing one sample every "sampleSize" to provide consistent
+	// memory usage across function executions
+	for i := 0; i < len(o.propNames); i += sampleSize {
+		k := o.propNames[i]
+		v := o.values[k]
+		if v == nil {
+			continue
+		}
+
+		inc, err := v.MemUsage(ctx)
+		samplesVisited += 1
+		total += inc
+		kMem := uint64(len(k))
+		total += kMem
+		averageMemUsage = float32(total) / float32(samplesVisited)
+		if err != nil {
+			return uint64(averageMemUsage * float32(len(o.propNames))), err
+		}
+	}
+
+	return uint64(averageMemUsage * float32(len(o.propNames))), nil
+}
+
 func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 	if o == nil || ctx.IsObjVisited(o) {
 		return SizeEmpty, nil
@@ -1936,19 +1969,26 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 	}
 
 	total := SizeEmpty
-
-	for _, k := range o.propNames {
-		v := o.values[k]
-		if v == nil {
-			continue
-		}
-
-		inc, err := v.MemUsage(ctx)
+	if ctx.ObjectPropsLenExceedsThreshold(len(o.propNames)) {
+		inc, err := o.estimateMemUsage(ctx)
 		total += inc
-		total += uint64(len(k))
-
 		if err != nil {
 			return total, err
+		}
+	} else {
+		for _, k := range o.propNames {
+			v := o.values[k]
+			if v == nil {
+				continue
+			}
+
+			inc, err := v.MemUsage(ctx)
+			total += inc
+			total += uint64(len(k))
+
+			if err != nil {
+				return total, err
+			}
 		}
 	}
 


### PR DESCRIPTION
I tested this in `baas` with a function like

```
exports = async function(arg){
  i = 0;
  testObj = {};
  while (true) {
    testObj[i] = "a";
    i++;
  }
  return "hello";
};
```

the before and after was quite a big difference, with this change we threw an error much faster!

This might not address nested objects, but the sampling will mitigate that. We would probably need a follow up to this change to better take that into account.