### PR TITLE
BAAS-23396: add strings overhead to mem usage calculations

### DIFF
--- a/added_values.go
+++ b/added_values.go
@@ -8,8 +8,8 @@ import (
 	"github.com/dop251/goja/unistring"
 )
 
-func (i valueNumber) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeNumber, nil
+func (i valueNumber) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeNumber, SizeNumber, nil
 }
 
 func (i valueNumber) ToInteger() int64 {
@@ -205,8 +205,8 @@ func (i valueNumber) ExportType() reflect.Type {
 	return i._type
 }
 
-func (i valueUInt32) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeInt32, nil
+func (i valueUInt32) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeInt32, SizeInt32, nil
 }
 
 func (i valueUInt32) ToInt() int {
@@ -335,8 +335,8 @@ func (i valueUInt32) ExportType() reflect.Type {
 	return reflectTypeUInt32
 }
 
-func (i valueInt32) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeInt32, nil
+func (i valueInt32) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeInt32, SizeInt32, nil
 }
 
 func (i valueInt32) hash(*maphash.Hash) uint64 {
@@ -464,8 +464,8 @@ func (i valueInt32) ExportType() reflect.Type {
 	return reflectTypeInt32
 }
 
-func (i valueInt64) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeNumber, nil
+func (i valueInt64) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeNumber, SizeNumber, nil
 }
 
 func (i valueInt64) ToInt() int {

--- a/added_values_test.go
+++ b/added_values_test.go
@@ -57,28 +57,28 @@ func TestAddedValuesMemUsage(t *testing.T) {
 		expectedNewMem uint64
 	}{
 		{
-			"should have memory usage of SizeNumber given a non-empty valueNumber",
-			valueNumber{val: 0},
-			SizeNumber,
-			SizeNumber,
+			name:           "should have memory usage of SizeNumber given a non-empty valueNumber",
+			val:            valueNumber{val: 0},
+			expectedMem:    SizeNumber,
+			expectedNewMem: SizeNumber,
 		},
 		{
-			"should have memory usage of SizeInt32 given a non-empty valueUInt32",
-			valueUInt32(1),
-			SizeInt32,
-			SizeInt32,
+			name:           "should have memory usage of SizeInt32 given a non-empty valueUInt32",
+			val:            valueUInt32(1),
+			expectedMem:    SizeInt32,
+			expectedNewMem: SizeInt32,
 		},
 		{
-			"should have memory usage of SizeInt32 given a non-empty valueInt32",
-			valueInt32(1),
-			SizeInt32,
-			SizeInt32,
+			name:           "should have memory usage of SizeInt32 given a non-empty valueInt32",
+			val:            valueInt32(1),
+			expectedMem:    SizeInt32,
+			expectedNewMem: SizeInt32,
 		},
 		{
-			"should have memory usage of SizeNumber given a non-empty valueInt64",
-			valueInt64(1),
-			SizeNumber,
-			SizeNumber,
+			name:           "should have memory usage of SizeNumber given a non-empty valueInt64",
+			val:            valueInt64(1),
+			expectedMem:    SizeNumber,
+			expectedNewMem: SizeNumber,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/added_values_test.go
+++ b/added_values_test.go
@@ -46,3 +46,52 @@ func TestIntStringEquality(t *testing.T) {
 		t.Fatal("values should not be equal")
 	}
 }
+
+func TestAddedValuesMemUsage(t *testing.T) {
+	vm := New()
+
+	for _, tc := range []struct {
+		name           string
+		val            MemUsageReporter
+		expectedMem    uint64
+		expectedNewMem uint64
+	}{
+		{
+			"should have memory usage of SizeNumber given a non-empty valueNumber",
+			valueNumber{val: 0},
+			SizeNumber,
+			SizeNumber,
+		},
+		{
+			"should have memory usage of SizeInt32 given a non-empty valueUInt32",
+			valueUInt32(1),
+			SizeInt32,
+			SizeInt32,
+		},
+		{
+			"should have memory usage of SizeInt32 given a non-empty valueInt32",
+			valueInt32(1),
+			SizeInt32,
+			SizeInt32,
+		},
+		{
+			"should have memory usage of SizeNumber given a non-empty valueInt64",
+			valueInt64(1),
+			SizeNumber,
+			SizeNumber,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem, newMem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, nil))
+			if err != nil {
+				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
+			}
+			if mem != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", mem, tc.expectedMem)
+			}
+			if newMem != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newMem, tc.expectedNewMem)
+			}
+		})
+	}
+}

--- a/array.go
+++ b/array.go
@@ -562,8 +562,8 @@ var (
 // With this function we sample 10% of the array values,
 // determine their average mem usage and use that to estimate mem
 // usage of the whole array
-func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	var samplesVisited, runningEstimate, newRunningEstimate uint64
+func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, newEstimate uint64, err error) {
+	var samplesVisited, memUsage, newMemUsage uint64
 	sampleSize := len(a.values) / 10
 
 	// grabbing one sample every "sampleSize" to provide consistent
@@ -578,17 +578,17 @@ func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, n
 		memUsage += inc
 		newMemUsage += newInc
 		// average * number of a.values
-		runningEstimate = uint64((float32(memUsage) / float32(samplesVisited)) * float32(len(a.values)))
-		newRunningEstimate = uint64((float32(newMemUsage) / float32(samplesVisited)) * float32(len(a.values)))
+		estimate = uint64((float32(memUsage) / float32(samplesVisited)) * float32(len(a.values)))
+		newEstimate = uint64((float32(newMemUsage) / float32(samplesVisited)) * float32(len(a.values)))
 		if err != nil {
-			return runningEstimate, newRunningEstimate, err
+			return estimate, newEstimate, err
 		}
-		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
-			return memUsage, newMemUsage, nil
+		if exceeded := ctx.MemUsageLimitExceeded(estimate); exceeded {
+			return estimate, newEstimate, nil
 		}
 	}
 
-	return runningEstimate, newRunningEstimate, nil
+	return estimate, newEstimate, nil
 }
 
 func (a *arrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {

--- a/array.go
+++ b/array.go
@@ -562,8 +562,8 @@ var (
 // With this function we sample 10% of the array values,
 // determine their average mem usage and use that to estimate mem
 // usage of the whole array
-func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
-	var total, samplesVisited, runningEstimate uint64
+func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	var samplesVisited, runningEstimate, newRunningEstimate uint64
 	sampleSize := len(a.values) / 10
 
 	// grabbing one sample every "sampleSize" to provide consistent
@@ -573,51 +573,58 @@ func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 			continue
 		}
 
-		inc, err := a.values[i].MemUsage(ctx)
+		inc, newInc, err := a.values[i].MemUsage(ctx)
 		samplesVisited += 1
-		total += inc
+		memUsage += inc
+		newMemUsage += newInc
 		// average * number of a.values
-		runningEstimate = uint64((float32(total) / float32(samplesVisited)) * float32(len(a.values)))
+		runningEstimate = uint64((float32(memUsage) / float32(samplesVisited)) * float32(len(a.values)))
+		newRunningEstimate = uint64((float32(newMemUsage) / float32(samplesVisited)) * float32(len(a.values)))
 		if err != nil {
-			return runningEstimate, err
+			return runningEstimate, newRunningEstimate, err
 		}
-		if exceeded := ctx.MemUsageLimitExceeded(total); exceeded {
-			return total, nil
+		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+			return memUsage, newMemUsage, nil
 		}
 	}
 
-	return runningEstimate, nil
+	return runningEstimate, newRunningEstimate, nil
 }
 
-func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (a *arrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(a)
 
-	total := SizeEmpty
-	inc, err := a.baseObject.MemUsage(ctx)
-	total += inc
+	// arrayObject overhead
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
+
+	inc, newInc, err := a.baseObject.MemUsage(ctx)
+	memUsage += inc
+	newMemUsage += newInc
 	if err != nil {
-		return total, err
+		return memUsage, newMemUsage, err
 	}
 
 	if err := ctx.Descend(); err != nil {
-		return total, err
+		return memUsage, newMemUsage, err
 	}
 
 	if ctx.ArrayLenExceedsThreshold == nil {
-		return total, errArrayLenExceedsThresholdNil
+		return memUsage, newMemUsage, errArrayLenExceedsThresholdNil
 	}
 	if ctx.ArrayLenExceedsThreshold(len(a.values)) {
-		inc, err := a.estimateMemUsage(ctx)
-		total += inc
+		inc, newInc, err := a.estimateMemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 
 		ctx.Ascend()
-		return total, nil
+		return memUsage, newMemUsage, nil
 	}
 
 	for _, v := range a.values {
@@ -625,18 +632,19 @@ func (a *arrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 			continue
 		}
 
-		inc, err := v.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := v.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 		// This is an early exit in case we reach the mem usage
 		// limit before we get to scan the whole array.
-		if exceeded := ctx.MemUsageLimitExceeded(total); exceeded {
-			return total, nil
+		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+			return memUsage, newMemUsage, nil
 		}
 	}
 
 	ctx.Ascend()
-	return total, nil
+	return memUsage, newMemUsage, nil
 }

--- a/array.go
+++ b/array.go
@@ -593,13 +593,13 @@ func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, n
 
 func (a *arrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(a)
 
 	// arrayObject overhead
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 
 	inc, newInc, err := a.baseObject.MemUsage(ctx)
 	memUsage += inc

--- a/array.go
+++ b/array.go
@@ -615,6 +615,13 @@ func (a *arrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsa
 	if ctx.ArrayLenExceedsThreshold == nil {
 		return memUsage, newMemUsage, errArrayLenExceedsThresholdNil
 	}
+
+	// slice overhead from a.values
+	if a.values != nil {
+		memUsage += 0
+		newMemUsage += SizeEmptySlice
+	}
+
 	if ctx.ArrayLenExceedsThreshold(len(a.values)) {
 		inc, newInc, err := a.estimateMemUsage(ctx)
 		memUsage += inc

--- a/array_sparse.go
+++ b/array_sparse.go
@@ -487,35 +487,40 @@ func (a *sparseArrayObject) exportToArrayOrSlice(dst reflect.Value, typ reflect.
 	return a.baseObject.exportToArrayOrSlice(dst, typ, ctx)
 }
 
-func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(a)
 
 	if err := ctx.Descend(); err != nil {
-		return SizeEmpty, err
+		return SizeEmpty, SizeEmpty, err
 	}
 
-	total := SizeEmpty
+	// sparseArrayObject overhead
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
+
 	for _, item := range a.items {
 		// Add the size of the index
-		total += SizeInt32
+		memUsage += SizeInt32
+		newMemUsage += SizeInt32
 		if item.value != nil {
-			inc, err := item.value.MemUsage(ctx)
-			total += inc
+			inc, newInc, err := item.value.MemUsage(ctx)
+			memUsage += inc
+			newMemUsage += newInc
 			if err != nil {
-				return total, err
+				return memUsage, newMemUsage, err
 			}
-			if exceeded := ctx.MemUsageLimitExceeded(total); exceeded {
-				return total, nil
+			if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+				return memUsage, newMemUsage, nil
 			}
 		}
 	}
 
 	ctx.Ascend()
 
-	inc, err := a.baseObject.MemUsage(ctx)
-	total += inc
-	return total, err
+	inc, newInc, err := a.baseObject.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }

--- a/array_sparse.go
+++ b/array_sparse.go
@@ -489,17 +489,17 @@ func (a *sparseArrayObject) exportToArrayOrSlice(dst reflect.Value, typ reflect.
 
 func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(a)
 
 	if err := ctx.Descend(); err != nil {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
 
 	// sparseArrayObject overhead
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 
 	for _, item := range a.items {
 		// Add the size of the index

--- a/array_sparse_test.go
+++ b/array_sparse_test.go
@@ -284,17 +284,17 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// array overhead + index size + stringObject + sparseArray baseObject
-			expected: SizeEmpty + SizeInt32 + 25 + SizeEmpty,
+			expected: SizeEmptyStruct + SizeInt32 + 25 + SizeEmptyStruct,
 			// array overhead + index size + stringObject + sparseArray baseObject
-			newExpected: SizeEmpty + SizeInt32 + 57 + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeInt32 + 57 + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "mem is SizeEmpty for nil sparse array",
+			name:        "mem is SizeEmptyStruct for nil sparse array",
 			mu:          NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
 			sao:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -329,9 +329,9 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// array overhead + index size + stringObject (we reach the limit at 4)
-			expected: SizeEmpty + (SizeInt32+26)*4,
+			expected: SizeEmptyStruct + (SizeInt32+26)*4,
 			// index size + stringObject (we reach the limit at 4)
-			newExpected: SizeEmpty + (SizeInt32+58)*4,
+			newExpected: SizeEmptyStruct + (SizeInt32+58)*4,
 			errExpected: nil,
 		},
 	}

--- a/array_sparse_test.go
+++ b/array_sparse_test.go
@@ -269,6 +269,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 		mu          *MemUsageContext
 		sao         *sparseArrayObject
 		expected    uint64
+		newExpected uint64
 		errExpected error
 	}{
 		{
@@ -282,7 +283,18 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 					},
 				},
 			},
-			expected:    45,
+			// array overhead + index size + stringObject + sparseArray baseObject
+			expected: SizeEmpty + SizeInt32 + 25 + SizeEmpty,
+			// array overhead + index size + stringObject + sparseArray baseObject
+			newExpected: SizeEmpty + SizeInt32 + 57 + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "mem is SizeEmpty for nil sparse array",
+			mu:          NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			sao:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
 			errExpected: nil,
 		},
 		{
@@ -292,7 +304,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 				items: []sparseArrayItem{
 					{
 						idx:   1,
-						value: New()._newString(newStringValue("key"), nil),
+						value: New()._newString(newStringValue("key0"), nil),
 					},
 					{
 						idx:   2,
@@ -316,22 +328,28 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 					},
 				},
 			},
-			expected:    127,
+			// array overhead + index size + stringObject (we reach the limit at 4)
+			expected: SizeEmpty + (SizeInt32+26)*4,
+			// index size + stringObject (we reach the limit at 4)
+			newExpected: SizeEmpty + (SizeInt32+58)*4,
 			errExpected: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.sao.MemUsage(tc.mu)
-			if err == nil && tc.errExpected != nil || err != nil && tc.errExpected == nil {
-				t.Fatalf("Unexpected error. Actual: %v Expected; %v", err, tc.errExpected)
+			total, newTotal, err := tc.sao.MemUsage(tc.mu)
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if total != tc.expected {
 				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
 			}
 		})
 	}

--- a/array_test.go
+++ b/array_test.go
@@ -136,34 +136,22 @@ func TestArrayObjectMemUsage(t *testing.T) {
 	vm := New()
 
 	tests := []struct {
-		name        string
-		mu          *MemUsageContext
-		ao          *arrayObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		mu             *MemUsageContext
+		ao             *arrayObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
 			name: "mem below threshold",
 			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
-			ao: &arrayObject{
-				values: []Value{
-					vm._newString(newStringValue("key"), nil),
-				},
-			},
+			ao:   &arrayObject{},
 			// array overhead + array baseObject
-			expected: SizeEmptyStruct + SizeEmptyStruct +
-				// stringObject + baseObject + prop "length"
-				(SizeEmptyStruct + SizeEmptyStruct + 6) +
-				// len("key")
-				3,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// array overhead + array baseObject
-			newExpected: SizeEmptyStruct + SizeEmptyStruct +
-				// stringObject + baseObject + prop "length" with string overhead
-				(SizeEmptyStruct + SizeEmptyStruct + (6 + SizeString)) +
-				// len("key") with string overhead
-				(3 + SizeString),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
@@ -179,13 +167,13 @@ func TestArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// array overhead + array baseObject
-			expected: SizeEmptyStruct + SizeEmptyStruct +
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct +
 				// (stringObject + baseObject + prop "length") * entries (at 4 we reach the limit)
 				(SizeEmptyStruct+SizeEmptyStruct+6)*4 +
 				// len("keyN") * entries (at 4 we reach the limit)
 				4*4,
 			// array overhead + array baseObject
-			newExpected: SizeEmptyStruct + SizeEmptyStruct +
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct +
 				// (stringObject + baseObject + prop "length" with string overhead) * entries (at 4 we reach the limit)
 				(SizeEmptyStruct+SizeEmptyStruct+(6+SizeString))*4 +
 				// len("keyN") with string overhead * entries (at 4 we reach the limit)
@@ -212,9 +200,9 @@ func TestArrayObjectMemUsage(t *testing.T) {
 			ao: &arrayObject{
 				values: []Value{vm._newString(newStringValue("key"), nil)},
 			},
-			expected:    SizeEmptyStruct + SizeEmptyStruct,
-			newExpected: SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: errArrayLenExceedsThresholdNil,
+			expectedMem:    SizeEmptyStruct + SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    errArrayLenExceedsThresholdNil,
 		},
 	}
 
@@ -227,11 +215,11 @@ func TestArrayObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/array_test.go
+++ b/array_test.go
@@ -144,13 +144,23 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		errExpected    error
 	}{
 		{
-			name: "mem below threshold",
+			name: "mem below threshold given a nil slice of values",
 			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
 			ao:   &arrayObject{},
 			// array overhead + array baseObject
 			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// array overhead + array baseObject
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
+		},
+		{
+			name: "mem below threshold given empty slice of values",
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			ao:   &arrayObject{values: []Value{}},
+			// array overhead + array baseObject
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
+			// array overhead + array baseObject + values slice overhead
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice,
 			errExpected:    nil,
 		},
 		{
@@ -172,8 +182,8 @@ func TestArrayObjectMemUsage(t *testing.T) {
 				(SizeEmptyStruct+SizeEmptyStruct+6)*4 +
 				// len("keyN") * entries (at 4 we reach the limit)
 				4*4,
-			// array overhead + array baseObject
-			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct +
+			// array overhead + array baseObject + values slice overhead
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice +
 				// (stringObject + baseObject + prop "length" with string overhead) * entries (at 4 we reach the limit)
 				(SizeEmptyStruct+SizeEmptyStruct+(6+SizeString))*4 +
 				// len("keyN") with string overhead * entries (at 4 we reach the limit)

--- a/array_test.go
+++ b/array_test.go
@@ -133,38 +133,63 @@ func BenchmarkArraySetEmpty(b *testing.B) {
 }
 
 func TestArrayObjectMemUsage(t *testing.T) {
+	vm := New()
+
 	tests := []struct {
 		name        string
 		mu          *MemUsageContext
 		ao          *arrayObject
 		expected    uint64
+		newExpected uint64
 		errExpected error
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{
-					New()._newString(newStringValue("key"), nil),
+					vm._newString(newStringValue("key"), nil),
 				},
 			},
-			expected:    41,
+			// array overhead + array baseObject
+			expected: SizeEmpty + SizeEmpty +
+				// stringObject + baseObject + prop "length"
+				(SizeEmpty + SizeEmpty + 6) +
+				// len("key")
+				3,
+			// array overhead + array baseObject
+			newExpected: SizeEmpty + SizeEmpty +
+				// stringObject + baseObject + prop "length" with string overhead
+				(SizeEmpty + SizeEmpty + (6 + SizeString)) +
+				// len("key") with string overhead
+				(3 + SizeString),
 			errExpected: nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(New(), 88, 100, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{
-					New()._newString(newStringValue("key"), nil),
-					New()._newString(newStringValue("key1"), nil),
-					New()._newString(newStringValue("key2"), nil),
-					New()._newString(newStringValue("key3"), nil),
-					New()._newString(newStringValue("key4"), nil),
-					New()._newString(newStringValue("key5"), nil),
+					vm._newString(newStringValue("key0"), nil),
+					vm._newString(newStringValue("key1"), nil),
+					vm._newString(newStringValue("key2"), nil),
+					vm._newString(newStringValue("key3"), nil),
+					vm._newString(newStringValue("key4"), nil),
+					vm._newString(newStringValue("key5"), nil),
 				},
 			},
-			expected:    119,
+			// array overhead + array baseObject
+			expected: SizeEmpty + SizeEmpty +
+				// (stringObject + baseObject + prop "length") * entries (at 4 we reach the limit)
+				(SizeEmpty+SizeEmpty+6)*4 +
+				// len("keyN") * entries (at 4 we reach the limit)
+				4*4,
+			// array overhead + array baseObject
+			newExpected: SizeEmpty + SizeEmpty +
+				// (stringObject + baseObject + prop "length" with string overhead) * entries (at 4 we reach the limit)
+				(SizeEmpty+SizeEmpty+(6+SizeString))*4 +
+				// len("keyN") with string overhead * entries (at 4 we reach the limit)
+				(4+SizeString)*4,
 			errExpected: nil,
 		},
 		{
@@ -185,24 +210,28 @@ func TestArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			ao: &arrayObject{
-				values: []Value{New()._newString(newStringValue("key"), nil)},
+				values: []Value{vm._newString(newStringValue("key"), nil)},
 			},
-			expected:    16,
+			expected:    SizeEmpty + SizeEmpty,
+			newExpected: SizeEmpty + SizeEmpty,
 			errExpected: errArrayLenExceedsThresholdNil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.ao.MemUsage(tc.mu)
-			if err == nil && tc.errExpected != nil || err != nil && tc.errExpected == nil {
-				t.Fatalf("Unexpected error. Actual: %v Expected; %v", err, tc.errExpected)
+			total, newTotal, err := tc.ao.MemUsage(tc.mu)
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if total != tc.expected {
 				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
 			}
 		})
 	}

--- a/array_test.go
+++ b/array_test.go
@@ -152,15 +152,15 @@ func TestArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// array overhead + array baseObject
-			expected: SizeEmpty + SizeEmpty +
+			expected: SizeEmptyStruct + SizeEmptyStruct +
 				// stringObject + baseObject + prop "length"
-				(SizeEmpty + SizeEmpty + 6) +
+				(SizeEmptyStruct + SizeEmptyStruct + 6) +
 				// len("key")
 				3,
 			// array overhead + array baseObject
-			newExpected: SizeEmpty + SizeEmpty +
+			newExpected: SizeEmptyStruct + SizeEmptyStruct +
 				// stringObject + baseObject + prop "length" with string overhead
-				(SizeEmpty + SizeEmpty + (6 + SizeString)) +
+				(SizeEmptyStruct + SizeEmptyStruct + (6 + SizeString)) +
 				// len("key") with string overhead
 				(3 + SizeString),
 			errExpected: nil,
@@ -179,15 +179,15 @@ func TestArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// array overhead + array baseObject
-			expected: SizeEmpty + SizeEmpty +
+			expected: SizeEmptyStruct + SizeEmptyStruct +
 				// (stringObject + baseObject + prop "length") * entries (at 4 we reach the limit)
-				(SizeEmpty+SizeEmpty+6)*4 +
+				(SizeEmptyStruct+SizeEmptyStruct+6)*4 +
 				// len("keyN") * entries (at 4 we reach the limit)
 				4*4,
 			// array overhead + array baseObject
-			newExpected: SizeEmpty + SizeEmpty +
+			newExpected: SizeEmptyStruct + SizeEmptyStruct +
 				// (stringObject + baseObject + prop "length" with string overhead) * entries (at 4 we reach the limit)
-				(SizeEmpty+SizeEmpty+(6+SizeString))*4 +
+				(SizeEmptyStruct+SizeEmptyStruct+(6+SizeString))*4 +
 				// len("keyN") with string overhead * entries (at 4 we reach the limit)
 				(4+SizeString)*4,
 			errExpected: nil,
@@ -212,8 +212,8 @@ func TestArrayObjectMemUsage(t *testing.T) {
 			ao: &arrayObject{
 				values: []Value{vm._newString(newStringValue("key"), nil)},
 			},
-			expected:    SizeEmpty + SizeEmpty,
-			newExpected: SizeEmpty + SizeEmpty,
+			expected:    SizeEmptyStruct + SizeEmptyStruct,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: errArrayLenExceedsThresholdNil,
 		},
 	}

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -96,7 +96,7 @@ func (mo *mapObject) exportToMap(dst reflect.Value, typ reflect.Type, ctx *objec
 
 func (mo *mapObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if mo == nil || ctx.IsObjVisited(mo) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(mo)
 

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -101,7 +101,7 @@ func (mo *mapObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsag
 	ctx.VisitObj(mo)
 
 	if err := ctx.Descend(); err != nil {
-		return 0, 0, err
+		return memUsage, newMemUsage, err
 	}
 
 	memUsage, newMemUsage, err = mo.baseObject.MemUsage(ctx)

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -94,19 +94,19 @@ func (mo *mapObject) exportToMap(dst reflect.Value, typ reflect.Type, ctx *objec
 	return nil
 }
 
-func (mo *mapObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (mo *mapObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if mo == nil || ctx.IsObjVisited(mo) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(mo)
 
 	if err := ctx.Descend(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	total, err := mo.baseObject.MemUsage(ctx)
+	memUsage, newMemUsage, err = mo.baseObject.MemUsage(ctx)
 	if err != nil {
-		return total, err
+		return memUsage, newMemUsage, err
 	}
 
 	for _, entry := range mo.m.hashTable {
@@ -115,28 +115,30 @@ func (mo *mapObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 		}
 
 		if entry.key != nil {
-			inc, err := entry.key.MemUsage(ctx)
-			total += inc
+			inc, newInc, err := entry.key.MemUsage(ctx)
+			memUsage += inc
+			newMemUsage += newInc
 			if err != nil {
-				return total, err
+				return memUsage, newMemUsage, err
 			}
 		}
 
 		if entry.value != nil {
-			inc, err := entry.value.MemUsage(ctx)
-			total += inc
+			inc, newInc, err := entry.value.MemUsage(ctx)
+			memUsage += inc
+			newMemUsage += newInc
 			if err != nil {
-				return total, err
+				return memUsage, newMemUsage, err
 			}
 		}
-		if exceeded := ctx.MemUsageLimitExceeded(total); exceeded {
-			return total, nil
+		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+			return memUsage, newMemUsage, nil
 		}
 	}
 
 	ctx.Ascend()
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
 func (r *Runtime) mapProto_clear(call FunctionCall) Value {

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -245,12 +245,12 @@ func BenchmarkMapDeleteJS(b *testing.B) {
 
 func TestMapObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		mu          *MemUsageContext
-		mo          *mapObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		mu             *MemUsageContext
+		mo             *mapObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
 			name: "mem below threshold",
@@ -266,18 +266,18 @@ func TestMapObjectMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject + stringObject + len(key) + stringObject + len(key)
-			expected: SizeEmptyStruct + 22 + 3 + 22 + 5,
+			expectedMem: SizeEmptyStruct + 22 + 3 + 22 + 5,
 			// baseObject + stringObject + (len(key) + overhead) + stringObject + (len(key) + overhead)
-			newExpected: SizeEmptyStruct + 38 + (3 + SizeString) + 38 + (5 + SizeString),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + 38 + (3 + SizeString) + 38 + (5 + SizeString),
+			errExpected:    nil,
 		},
 		{
-			name:        "mem is SizeEmptyStruct given a nil map object",
-			mu:          NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
-			mo:          nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "mem is SizeEmptyStruct given a nil map object",
+			mu:             NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mo:             nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
@@ -305,13 +305,13 @@ func TestMapObjectMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject
-			expected: SizeEmptyStruct +
+			expectedMem: SizeEmptyStruct +
 				// stringObject + len(key) (we reach the limit after 2)
 				(22+3)*2 +
 				// stringObject + len(value) (we reach the limit after 2)
 				(22+5)*2,
 			// baseObject
-			newExpected: SizeEmptyStruct +
+			expectedNewMem: SizeEmptyStruct +
 				// stringObject + len(key) + overhead (we reach the limit after 2)
 				(38+(3+SizeString))*2 +
 				// stringObject + len(value) + overhead (we reach the limit after 2)
@@ -329,11 +329,11 @@ func TestMapObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -249,6 +249,7 @@ func TestMapObjectMemUsage(t *testing.T) {
 		mu          *MemUsageContext
 		mo          *mapObject
 		expected    uint64
+		newExpected uint64
 		errExpected error
 	}{
 		{
@@ -264,7 +265,18 @@ func TestMapObjectMemUsage(t *testing.T) {
 					},
 				},
 			},
-			expected:    60,
+			// baseObject + stringObject + len(key) + stringObject + len(key)
+			expected: SizeEmpty + 22 + 3 + 22 + 5,
+			// baseObject + stringObject + (len(key) + overhead) + stringObject + (len(key) + overhead)
+			newExpected: SizeEmpty + 38 + (3 + SizeString) + 38 + (5 + SizeString),
+			errExpected: nil,
+		},
+		{
+			name:        "mem is SizeEmpty given a nil map object",
+			mu:          NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mo:          nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
 			errExpected: nil,
 		},
 		{
@@ -292,22 +304,36 @@ func TestMapObjectMemUsage(t *testing.T) {
 					},
 				},
 			},
-			expected:    112,
+			// baseObject
+			expected: SizeEmpty +
+				// stringObject + len(key) (we reach the limit after 2)
+				(22+3)*2 +
+				// stringObject + len(value) (we reach the limit after 2)
+				(22+5)*2,
+			// baseObject
+			newExpected: SizeEmpty +
+				// stringObject + len(key) + overhead (we reach the limit after 2)
+				(38+(3+SizeString))*2 +
+				// stringObject + len(value) + overhead (we reach the limit after 2)
+				(38+(5+SizeString))*2,
 			errExpected: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.mo.MemUsage(tc.mu)
-			if err == nil && tc.errExpected != nil || err != nil && tc.errExpected == nil {
-				t.Fatalf("Unexpected error. Actual: %v Expected; %v", err, tc.errExpected)
+			total, newTotal, err := tc.mo.MemUsage(tc.mu)
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if total != tc.expected {
 				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
 			}
 		})
 	}

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -266,17 +266,17 @@ func TestMapObjectMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject + stringObject + len(key) + stringObject + len(key)
-			expected: SizeEmpty + 22 + 3 + 22 + 5,
+			expected: SizeEmptyStruct + 22 + 3 + 22 + 5,
 			// baseObject + stringObject + (len(key) + overhead) + stringObject + (len(key) + overhead)
-			newExpected: SizeEmpty + 38 + (3 + SizeString) + 38 + (5 + SizeString),
+			newExpected: SizeEmptyStruct + 38 + (3 + SizeString) + 38 + (5 + SizeString),
 			errExpected: nil,
 		},
 		{
-			name:        "mem is SizeEmpty given a nil map object",
+			name:        "mem is SizeEmptyStruct given a nil map object",
 			mu:          NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
 			mo:          nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -305,13 +305,13 @@ func TestMapObjectMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject
-			expected: SizeEmpty +
+			expected: SizeEmptyStruct +
 				// stringObject + len(key) (we reach the limit after 2)
 				(22+3)*2 +
 				// stringObject + len(value) (we reach the limit after 2)
 				(22+5)*2,
 			// baseObject
-			newExpected: SizeEmpty +
+			newExpected: SizeEmptyStruct +
 				// stringObject + len(key) + overhead (we reach the limit after 2)
 				(38+(3+SizeString))*2 +
 				// stringObject + len(value) + overhead (we reach the limit after 2)

--- a/builtin_proxy.go
+++ b/builtin_proxy.go
@@ -390,6 +390,6 @@ func (r *Runtime) initProxy() {
 	r.addToGlobal("Proxy", r.global.Proxy)
 }
 
-func (np *nativeProxyHandler) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return 0, nil
+func (h *nativeProxyHandler) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return memUsage, newMemUsage, err
 }

--- a/builtin_proxy_test.go
+++ b/builtin_proxy_test.go
@@ -1277,16 +1277,16 @@ func TestProxyEnumerableSymbols(t *testing.T) {
 
 func TestBuiltinProxyMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *nativeProxyHandler
-		expected    uint64
-		newExpected uint64
+		name           string
+		val            *nativeProxyHandler
+		expectedMem    uint64
+		expectedNewMem uint64
 	}{
 		{
-			name:        "should have a value of 0 given a native proxy handler",
-			val:         &nativeProxyHandler{},
-			expected:    0,
-			newExpected: 0,
+			name:           "should have a value of 0 given a native proxy handler",
+			val:            &nativeProxyHandler{},
+			expectedMem:    0,
+			expectedNewMem: 0,
 		},
 	}
 
@@ -1296,11 +1296,11 @@ func TestBuiltinProxyMemUsage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/builtin_proxy_test.go
+++ b/builtin_proxy_test.go
@@ -1274,3 +1274,34 @@ func TestProxyEnumerableSymbols(t *testing.T) {
 
 	testScriptWithTestLib(SCRIPT, valueTrue, t)
 }
+
+func TestBuiltinProxyMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *nativeProxyHandler
+		expected    uint64
+		newExpected uint64
+	}{
+		{
+			name:        "should have a value of 0 given a native proxy handler",
+			val:         &nativeProxyHandler{},
+			expected:    0,
+			newExpected: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != nil {
+				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/compiler.go
+++ b/compiler.go
@@ -457,24 +457,24 @@ func (p *Program) sourceOffset(pc int) int {
 	return 0
 }
 
-func (p *Program) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	total := uint64(0)
+func (p *Program) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	for _, val := range p.values {
 		if val == nil {
 			continue
 		}
 
-		inc, err := val.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := val.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
-		if exceeded := ctx.MemUsageLimitExceeded(total); exceeded {
-			return total, nil
+		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+			return memUsage, newMemUsage, nil
 		}
 	}
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
 func (p *Program) addSrcMap(srcPos int) {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5649,12 +5649,12 @@ func BenchmarkCompile(b *testing.B) {
 
 func TestProgramMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		mu          *MemUsageContext
-		p           *Program
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		mu             *MemUsageContext
+		p              *Program
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
 			name: "mem below threshold",
@@ -5665,10 +5665,10 @@ func TestProgramMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject + ms field in DateObject
-			expected: SizeEmptyStruct + SizeNumber,
+			expectedMem: SizeEmptyStruct + SizeNumber,
 			// baseObject + ms field in DateObject
-			newExpected: SizeEmptyStruct + SizeNumber,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeNumber,
+			errExpected:    nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
@@ -5687,10 +5687,10 @@ func TestProgramMemUsage(t *testing.T) {
 				},
 			},
 			// DateObject * 4 (we hit the limit at 4)
-			expected: (SizeEmptyStruct + SizeNumber) * 4,
+			expectedMem: (SizeEmptyStruct + SizeNumber) * 4,
 			// DateObject * 4 (we hit the limit at 4)
-			newExpected: (SizeEmptyStruct + SizeNumber) * 4,
-			errExpected: nil,
+			expectedNewMem: (SizeEmptyStruct + SizeNumber) * 4,
+			errExpected:    nil,
 		},
 	}
 
@@ -5703,11 +5703,11 @@ func TestProgramMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5665,9 +5665,9 @@ func TestProgramMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject + ms field in DateObject
-			expected: SizeEmpty + SizeNumber,
+			expected: SizeEmptyStruct + SizeNumber,
 			// baseObject + ms field in DateObject
-			newExpected: SizeEmpty + SizeNumber,
+			newExpected: SizeEmptyStruct + SizeNumber,
 			errExpected: nil,
 		},
 		{
@@ -5687,9 +5687,9 @@ func TestProgramMemUsage(t *testing.T) {
 				},
 			},
 			// DateObject * 4 (we hit the limit at 4)
-			expected: (SizeEmpty + SizeNumber) * 4,
+			expected: (SizeEmptyStruct + SizeNumber) * 4,
 			// DateObject * 4 (we hit the limit at 4)
-			newExpected: (SizeEmpty + SizeNumber) * 4,
+			newExpected: (SizeEmptyStruct + SizeNumber) * 4,
 			errExpected: nil,
 		},
 	}

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5653,6 +5653,7 @@ func TestProgramMemUsage(t *testing.T) {
 		mu          *MemUsageContext
 		p           *Program
 		expected    uint64
+		newExpected uint64
 		errExpected error
 	}{
 		{
@@ -5663,7 +5664,10 @@ func TestProgramMemUsage(t *testing.T) {
 					New().newDateObject(time.Now(), true, nil),
 				},
 			},
-			expected:    16,
+			// baseObject + ms field in DateObject
+			expected: SizeEmpty + SizeNumber,
+			// baseObject + ms field in DateObject
+			newExpected: SizeEmpty + SizeNumber,
 			errExpected: nil,
 		},
 		{
@@ -5682,22 +5686,28 @@ func TestProgramMemUsage(t *testing.T) {
 					New().newDateObject(time.Now(), true, nil),
 				},
 			},
-			expected:    64,
+			// DateObject * 4 (we hit the limit at 4)
+			expected: (SizeEmpty + SizeNumber) * 4,
+			// DateObject * 4 (we hit the limit at 4)
+			newExpected: (SizeEmpty + SizeNumber) * 4,
 			errExpected: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.p.MemUsage(tc.mu)
-			if err == nil && tc.errExpected != nil || err != nil && tc.errExpected == nil {
-				t.Fatalf("Unexpected error. Actual: %v Expected; %v", err, tc.errExpected)
+			total, newTotal, err := tc.p.MemUsage(tc.mu)
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
 			if total != tc.expected {
 				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
 			}
 		})
 	}

--- a/date.go
+++ b/date.go
@@ -176,7 +176,7 @@ func (d *dateObject) timeUTC() time.Time {
 
 func (d *dateObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if d == nil || ctx.IsObjVisited(d) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(d)
 

--- a/date.go
+++ b/date.go
@@ -174,15 +174,16 @@ func (d *dateObject) timeUTC() time.Time {
 	return timeFromMsec(d.msec).In(time.UTC)
 }
 
-func (d *dateObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (d *dateObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if d == nil || ctx.IsObjVisited(d) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(d)
 
 	// start with the size of msec
-	total := SizeNumber
-	inc, err := d.baseObject.MemUsage(ctx)
-	total += inc
-	return total, err
+	memUsage = SizeNumber
+	newMemUsage = SizeNumber
+	inc, newInc, err := d.baseObject.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }

--- a/date_test.go
+++ b/date_test.go
@@ -307,3 +307,48 @@ func TestDateExportType(t *testing.T) {
 		t.Fatal(typ)
 	}
 }
+
+func TestDateMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *dateObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name: "should have a value given by baseObject and msec",
+			val:  &dateObject{msec: int64(100)},
+			// baseObject + msec value
+			expected: SizeEmpty + SizeNumber,
+			// baseObject + msec value
+			newExpected: SizeEmpty + SizeNumber,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given a nil dateObject",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/date_test.go
+++ b/date_test.go
@@ -320,16 +320,16 @@ func TestDateMemUsage(t *testing.T) {
 			name: "should have a value given by baseObject and msec",
 			val:  &dateObject{msec: int64(100)},
 			// baseObject + msec value
-			expected: SizeEmpty + SizeNumber,
+			expected: SizeEmptyStruct + SizeNumber,
 			// baseObject + msec value
-			newExpected: SizeEmpty + SizeNumber,
+			newExpected: SizeEmptyStruct + SizeNumber,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given a nil dateObject",
+			name:        "should have a value of SizeEmptyStruct given a nil dateObject",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 	}

--- a/date_test.go
+++ b/date_test.go
@@ -3,6 +3,8 @@ package goja
 import (
 	"testing"
 	"time"
+
+	"github.com/dop251/goja/unistring"
 )
 
 func TestDateUTC(t *testing.T) {
@@ -310,27 +312,46 @@ func TestDateExportType(t *testing.T) {
 
 func TestDateMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *dateObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *dateObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name: "should have a value given by baseObject and msec",
+			name: "should have a value given by baseObject overhead and msec",
 			val:  &dateObject{msec: int64(100)},
 			// baseObject + msec value
-			expected: SizeEmptyStruct + SizeNumber,
+			expectedMem: SizeEmptyStruct + SizeNumber,
 			// baseObject + msec value
-			newExpected: SizeEmptyStruct + SizeNumber,
+			expectedNewMem: SizeEmptyStruct + SizeNumber,
+			errExpected:    nil,
+		},
+		{
+			name: "should have a value given by a non-empty baseObject and msec",
+			val: &dateObject{
+				msec: int64(100),
+				baseObject: baseObject{
+					propNames: []unistring.String{"test"},
+					values:    map[unistring.String]Value{"test": valueInt(99)},
+				},
+			},
+			// msec value
+			expectedMem: SizeNumber +
+				// baseObject overhead + len("test") + value
+				SizeEmptyStruct + 4 + SizeInt,
+			// msec value
+			expectedNewMem: SizeNumber +
+				// baseObject overhead + len("test") with string overhead + value
+				SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil dateObject",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil dateObject",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 	}
 
@@ -343,11 +364,11 @@ func TestDateMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/destruct.go
+++ b/destruct.go
@@ -304,9 +304,9 @@ func (d *destructKeyedSource) getPrivateEnv(typ *privateEnvType, create bool) *p
 	return d.w().getPrivateEnv(typ, create)
 }
 
-func (d *destructKeyedSource) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (d *destructKeyedSource) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if d.wrapped == nil {
-		return 0, nil
+		return memUsage, newMemUsage, err
 	}
 
 	return d.wrapped.MemUsage(ctx)

--- a/destruct_test.go
+++ b/destruct_test.go
@@ -1,0 +1,48 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestDestructMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *destructKeyedSource
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value given by the wrapped value",
+			val:         &destructKeyedSource{wrapped: valueInt(99)},
+			expected:    SizeInt, // wrapped value mem
+			newExpected: SizeInt, // wrapped value mem
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of 0 given a nil wrapped value",
+			val:         &destructKeyedSource{},
+			expected:    0,
+			newExpected: 0,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/destruct_test.go
+++ b/destruct_test.go
@@ -6,25 +6,25 @@ import (
 
 func TestDestructMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *destructKeyedSource
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *destructKeyedSource
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value given by the wrapped value",
-			val:         &destructKeyedSource{wrapped: valueInt(99)},
-			expected:    SizeInt, // wrapped value mem
-			newExpected: SizeInt, // wrapped value mem
-			errExpected: nil,
+			name:           "should have a value given by the wrapped value",
+			val:            &destructKeyedSource{wrapped: valueInt(99)},
+			expectedMem:    SizeInt, // wrapped value mem
+			expectedNewMem: SizeInt, // wrapped value mem
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of 0 given a nil wrapped value",
-			val:         &destructKeyedSource{},
-			expected:    0,
-			newExpected: 0,
-			errExpected: nil,
+			name:           "should have a value of 0 given a nil wrapped value",
+			val:            &destructKeyedSource{},
+			expectedMem:    0,
+			expectedNewMem: 0,
+			errExpected:    nil,
 		},
 	}
 
@@ -37,11 +37,11 @@ func TestDestructMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/func.go
+++ b/func.go
@@ -461,33 +461,34 @@ func (f *boundFuncObject) hasInstance(v Value) bool {
 	return instanceOfOperator(v, f.wrapped)
 }
 
-func (f *nativeFuncObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (f *nativeFuncObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if f == nil || ctx.IsObjVisited(f) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(f)
 
 	return f.baseFuncObject.MemUsage(ctx)
 }
 
-func (f *funcObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (f *funcObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if f == nil || ctx.IsObjVisited(f) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(f)
 
-	total, baseObjectErr := f.baseObject.MemUsage(ctx)
-	if baseObjectErr != nil {
-		return total, baseObjectErr
+	memUsage, newMemUsage, err = f.baseObject.MemUsage(ctx)
+	if err != nil {
+		return memUsage, newMemUsage, err
 	}
 
 	if f.stash != nil {
-		inc, err := f.stash.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := f.stash.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }

--- a/func.go
+++ b/func.go
@@ -463,7 +463,7 @@ func (f *boundFuncObject) hasInstance(v Value) bool {
 
 func (f *nativeFuncObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if f == nil || ctx.IsObjVisited(f) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(f)
 
@@ -472,7 +472,7 @@ func (f *nativeFuncObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newM
 
 func (f *funcObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if f == nil || ctx.IsObjVisited(f) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(f)
 

--- a/func_test.go
+++ b/func_test.go
@@ -163,25 +163,25 @@ func ExampleAssertConstructor() {
 
 func TestNativeFuncObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *nativeFuncObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *nativeFuncObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value given by the wrapped value",
-			val:         &nativeFuncObject{},
-			expected:    SizeEmptyStruct, // baseFuncObject
-			newExpected: SizeEmptyStruct, // baseFuncObject
-			errExpected: nil,
+			name:           "should have a value given by the wrapped value",
+			val:            &nativeFuncObject{},
+			expectedMem:    SizeEmptyStruct, // baseFuncObject
+			expectedNewMem: SizeEmptyStruct, // baseFuncObject
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil nativeFuncObject",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil nativeFuncObject",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 	}
 
@@ -194,11 +194,11 @@ func TestNativeFuncObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -206,25 +206,25 @@ func TestNativeFuncObjectMemUsage(t *testing.T) {
 
 func TestFuncObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *funcObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *funcObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil funcObject",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil funcObject",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value given by baseObject with no stash",
-			val:         &funcObject{},
-			expected:    SizeEmptyStruct, // baseFuncObject
-			newExpected: SizeEmptyStruct, // baseFuncObject
-			errExpected: nil,
+			name:           "should have a value given by baseObject with no stash",
+			val:            &funcObject{},
+			expectedMem:    SizeEmptyStruct, // baseFuncObject
+			expectedNewMem: SizeEmptyStruct, // baseFuncObject
+			errExpected:    nil,
 		},
 		{
 			name: "should have a value given by baseObject and values in stash",
@@ -236,10 +236,10 @@ func TestFuncObjectMemUsage(t *testing.T) {
 				},
 			},
 			// baseFuncObject + value in stash
-			expected: SizeEmptyStruct + SizeInt,
+			expectedMem: SizeEmptyStruct + SizeInt,
 			// baseFuncObject + value in stash
-			newExpected: SizeEmptyStruct + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
 		},
 	}
 
@@ -252,11 +252,11 @@ func TestFuncObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/func_test.go
+++ b/func_test.go
@@ -160,3 +160,104 @@ func ExampleAssertConstructor() {
 	}
 	// Output: Test
 }
+
+func TestNativeFuncObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *nativeFuncObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value given by the wrapped value",
+			val:         &nativeFuncObject{},
+			expected:    SizeEmpty, // baseFuncObject
+			newExpected: SizeEmpty, // baseFuncObject
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given a nil nativeFuncObject",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestFuncObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *funcObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil funcObject",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value given by baseObject with no stash",
+			val:         &funcObject{},
+			expected:    SizeEmpty, // baseFuncObject
+			newExpected: SizeEmpty, // baseFuncObject
+			errExpected: nil,
+		},
+		{
+			name: "should have a value given by baseObject and values in stash",
+			val: &funcObject{
+				baseJsFuncObject: baseJsFuncObject{
+					stash: &stash{
+						values: []Value{valueInt(0)},
+					},
+				},
+			},
+			// baseFuncObject + value in stash
+			expected: SizeEmpty + SizeInt,
+			// baseFuncObject + value in stash
+			newExpected: SizeEmpty + SizeInt,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/func_test.go
+++ b/func_test.go
@@ -172,15 +172,15 @@ func TestNativeFuncObjectMemUsage(t *testing.T) {
 		{
 			name:        "should have a value given by the wrapped value",
 			val:         &nativeFuncObject{},
-			expected:    SizeEmpty, // baseFuncObject
-			newExpected: SizeEmpty, // baseFuncObject
+			expected:    SizeEmptyStruct, // baseFuncObject
+			newExpected: SizeEmptyStruct, // baseFuncObject
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given a nil nativeFuncObject",
+			name:        "should have a value of SizeEmptyStruct given a nil nativeFuncObject",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 	}
@@ -213,17 +213,17 @@ func TestFuncObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil funcObject",
+			name:        "should have a value of SizeEmptyStruct given a nil funcObject",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name:        "should have a value given by baseObject with no stash",
 			val:         &funcObject{},
-			expected:    SizeEmpty, // baseFuncObject
-			newExpected: SizeEmpty, // baseFuncObject
+			expected:    SizeEmptyStruct, // baseFuncObject
+			newExpected: SizeEmptyStruct, // baseFuncObject
 			errExpected: nil,
 		},
 		{
@@ -236,9 +236,9 @@ func TestFuncObjectMemUsage(t *testing.T) {
 				},
 			},
 			// baseFuncObject + value in stash
-			expected: SizeEmpty + SizeInt,
+			expected: SizeEmptyStruct + SizeInt,
 			// baseFuncObject + value in stash
-			newExpected: SizeEmpty + SizeInt,
+			newExpected: SizeEmptyStruct + SizeInt,
 			errExpected: nil,
 		},
 	}

--- a/mem_context.go
+++ b/mem_context.go
@@ -55,38 +55,6 @@ type NativeMemUsageChecker interface {
 	NativeMemUsage(goNativeValue interface{}) (uint64, bool)
 }
 
-func (self *stash) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	if ctx.IsStashVisited(self) {
-		return 0, nil
-	}
-	ctx.VisitStash(self)
-	total := uint64(0)
-	if self.obj != nil {
-		inc, err := self.obj.MemUsage(ctx)
-		total += inc
-		if err != nil {
-			return total, err
-		}
-	}
-
-	if self.outer != nil {
-		inc, err := self.outer.MemUsage(ctx)
-		total += inc
-		if err != nil {
-			return total, err
-		}
-	}
-	if len(self.values) > 0 {
-		inc, err := self.values.MemUsage(ctx)
-		total += inc
-		if err != nil {
-			return total, err
-		}
-	}
-
-	return total, nil
-}
-
 type MemUsageContext struct {
 	visitTracker
 	*depthTracker

--- a/mem_context.go
+++ b/mem_context.go
@@ -130,5 +130,8 @@ var (
 )
 
 type MemUsageReporter interface {
-	MemUsage(ctx *MemUsageContext) (uint64, error)
+	// The newMemUsage value is used to allow tracking significant differences in how
+	// we track memory usage vs a more accurate tracking. This will help
+	// us evaluate the impact of any memory usage value change.
+	MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error)
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -33,80 +33,92 @@ func TestMemCheck(t *testing.T) {
 	var functionStackOverhead uint64 = 34
 
 	for _, tc := range []struct {
-		description      string
-		script           string
-		expectedSizeDiff uint64
+		desc                string
+		script              string
+		expectedSizeDiff    uint64
+		expectedNewSizeDiff uint64
 	}{
 		{
-			"number",
-			`x = []
+			desc: "number",
+			script: `x = []
 			x.push(0)
 			checkMem()
 			x.push(0)
 			checkMem()`,
-			SizeNumber,
+			expectedSizeDiff:    SizeNumber,
+			expectedNewSizeDiff: SizeNumber,
 		},
 		{
-			"boolean",
-			`x = []
+			desc: "boolean",
+			script: `x = []
 			x.push(true)
 			checkMem()
 			x.push(true)
 			checkMem()`,
-			SizeBool,
+			expectedSizeDiff:    SizeBool,
+			expectedNewSizeDiff: SizeBool,
 		},
 		{
-			"null",
-			`x = []
+			desc: "null",
+			script: `x = []
 			x.push(null)
 			checkMem()
 			x.push(null)
 			checkMem()`,
-			SizeEmpty,
+			expectedSizeDiff:    SizeEmpty,
+			expectedNewSizeDiff: SizeEmpty,
 		},
 		{
-			"undefined",
-			`x = []
+			desc: "undefined",
+			script: `x = []
 			x.push(undefined)
 			checkMem()
 			x.push(undefined)
 			checkMem()`,
-			SizeEmpty,
+			expectedSizeDiff:    SizeEmpty,
+			expectedNewSizeDiff: SizeEmpty,
 		},
 		{
-			"string",
-			`x = []
+			desc: "string",
+			script: `x = []
 			x.push("12345")
 			checkMem()
 			x.push("12345")
 			checkMem()`,
-			5 + SizeString,
+			expectedSizeDiff:    5,
+			expectedNewSizeDiff: 5 + SizeString,
 		},
 		{
-			"string with multi-byte characters",
-			`x = []
+			desc: "string with multi-byte characters",
+			script: `x = []
 			x.push("\u2318")
 			checkMem()
 			x.push("\u2318")
 			checkMem()`,
-			3 + SizeString, // single char with 3-byte width
+			expectedSizeDiff:    3, // single char with 3-byte width
+			expectedNewSizeDiff: 3 + SizeString,
 		},
 		{
-			"nested objects",
-			`y = []
+			desc: "nested objects",
+			script: `y = []
 			y.push(null)
 			checkMem()
 			y.push({"a":10, "b":"1234", "c":{}})
 			checkMem()`,
-			SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+			expectedSizeDiff: SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				1 + SizeNumber + // "a" and number 10
+				1 + 4 + // "b" and string "1234"
+				1 + SizeEmpty + SizeEmpty + //  "c" (object + prototype reference)
+				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
+			expectedNewSizeDiff: SizeEmpty + SizeEmpty + // outer object + reference to its prototype
 				(1 + SizeString) + SizeNumber + // "a" and number 10
 				(1 + SizeString) + (4 + SizeString) + // "b" and string "1234"
 				(1 + SizeString) + SizeEmpty + SizeEmpty + //  "c" (object + prototype reference)
-				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
+				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8),
 		},
 		{
-			"array of numbers",
-			`y = []
+			desc: "array of numbers",
+			script: `y = []
 			var i = 0;
 			y.push([]);
 			checkMem();
@@ -116,32 +128,38 @@ func TestMemCheck(t *testing.T) {
 			checkMem()`,
 			// Array overhead,
 			// size of property values,
-			SizeEmpty + 20*SizeNumber,
+			expectedSizeDiff:    SizeEmpty + 20*SizeNumber,
+			expectedNewSizeDiff: SizeEmpty + 20*SizeNumber,
 		},
 		{
-			"overhead of a single new scope",
-			`checkMem();
+			desc: "overhead of a single new scope",
+			script: `checkMem();
 			(function(){
 				checkMem();
 			})();`, // over
-			emptyFunctionScopeOverhead +
+			expectedSizeDiff: emptyFunctionScopeOverhead +
+				functionStackOverhead + // anonymous function on stack
+				SizeEmpty, // undefined return on stack
+			expectedNewSizeDiff: emptyFunctionScopeOverhead +
 				functionStackOverhead + // anonymous function on stack
 				SizeString + // empty string for anon function name
 				SizeString + SizeString + // overhead of "name" and "length" props on function object
-				SizeEmpty, // undefined return on stack
+				SizeEmpty, // undefined return on stack,
 		},
 		{
-			"previous function scopes should not affect the current memory",
-			`checkMem();
+			desc: "previous function scopes should not affect the current memory",
+			script: `checkMem();
 			(function(){
 			})();
 			checkMem();`,
-			0 +
+			expectedSizeDiff: 0 +
+				SizeEmpty, // undefined return value on stack
+			expectedNewSizeDiff: 0 +
 				SizeEmpty, // undefined return value on stack
 		},
 		{
-			"overhead of each scope is equivalent regardless of depth",
-			`checkMem();
+			desc: "overhead of each scope is equivalent regardless of depth",
+			script: `checkMem();
 			(function(){
 				(function(){
 					(function(){
@@ -155,29 +173,36 @@ func TestMemCheck(t *testing.T) {
 					})();
 				})();
 			})();`,
-			(6 * functionStackOverhead) + // anonymous functions on stack
+			expectedSizeDiff: (6 * functionStackOverhead) + // anonymous functions on stack
+				(6 * SizeEmpty) + // undefined return value for each function on stack
+				(6 * emptyFunctionScopeOverhead),
+			expectedNewSizeDiff: (6 * functionStackOverhead) + // anonymous functions on stack
 				(6 * SizeString) + // empty string for anon function name
 				(6 * (SizeString + SizeString)) + // overhead of "name" and "length" props on function object
 				(6 * SizeEmpty) + // undefined return value for each function on stack
 				(6 * emptyFunctionScopeOverhead),
 		},
 		{
-			"values attached to lexical scope in a function",
-			`checkMem();
+			desc: "values attached to lexical scope in a function",
+			script: `checkMem();
 			(function(){
 				var zzzx = 10;
 				checkMem();
 			})();`,
 			// function overhead plus the number value of the "zzzx" property and its string name
+			expectedSizeDiff: emptyFunctionScopeOverhead + SizeNumber + functionStackOverhead +
+				SizeEmpty + // undefined return value on stack
+				SizeNumber, // number 10 on stack
+			expectedNewSizeDiff: // function overhead plus the number value of the "zzzx" property and its string name
 			emptyFunctionScopeOverhead + SizeNumber + functionStackOverhead +
 				SizeString + // empty string for anon function name
 				SizeString + SizeString + // overhead of "name" and "length" props on function object
 				SizeEmpty + // undefined return value on stack
-				SizeNumber, // number 10 on stack
+				SizeNumber, // number 10 on stack,
 		},
 		{
-			"cyclical data structure",
-			// cyclical data structure does not recurse infinitely
+			desc: "cyclical data structure",
+			script: // cyclical data structure does not recurse infinitely
 			// and does not artificially inflate mem count. The only change in mem
 			// between the two checks is for the new property names for "y" and "x".
 			`var zzza = {}
@@ -186,92 +211,116 @@ func TestMemCheck(t *testing.T) {
 			 zzza.y = zzzb
 			 zzzb.x = zzza
 			 checkMem()`,
-			(1 + SizeString) + SizeEmpty + // "x" property name + references to object
-				(1 + SizeString) + SizeEmpty, // "y" property names + references to object
+			expectedSizeDiff: 1 + SizeEmpty + // "x" property name + references to object
+				1 + SizeEmpty, // "y" property names + references to object
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty + // "x" property name + references to object
+				(1 + SizeString) + SizeEmpty, // "y" property names + references to object,
 		},
 		{
-			"sparse array with arrayObject",
-			`x = []
+			desc: "sparse array with arrayObject",
+			script: `x = []
 			x[1] = "abcd";
 			checkMem()
 			x[10] = "abc";
 			checkMem()`,
-			2 + SizeString, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd"
+			expectedSizeDiff:    2,              // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd"
+			expectedNewSizeDiff: 2 + SizeString, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd",
 		},
 		{
-			"sparse array with sparseArrayObject",
-			`x = []
+			desc: "sparse array with sparseArrayObject",
+			script: `x = []
 			x[5000] = "abcd";
 			checkMem()
 			x[5001] = "abc";
 			checkMem()`,
-			SizeInt32 +
-				2 + SizeString, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd"
+			expectedSizeDiff: SizeInt32 +
+				2, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd"
+			expectedNewSizeDiff: SizeInt32 +
+				2 + SizeString, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd",
 		},
 		{
-			"array with non-numeric keys",
-			`x = []
+			desc: "array with non-numeric keys",
+			script: `x = []
 			x[0] = 3;
 			checkMem()
 			x["a"] = "abc";
 			x[1] = 3;
 			checkMem()
 			`,
-			1 + SizeString + // len("a")
-				3 + SizeString + // len("abc")
+			expectedSizeDiff: 1 + // len("a")
+				3 + // len("abc")
 				SizeNumber, // number 3
+			expectedNewSizeDiff: 1 + SizeString + // len("a")
+				3 + SizeString + // len("abc")
+				SizeNumber, // number 3,
 		},
 		{
-			"reference to array",
-			`x = []
+			desc: "reference to array",
+			script: `x = []
 			x[1] = "abcd";
 			x[10] = "abc";
 			checkMem()
 			y = x;
 			checkMem()`,
 			// len("y") + reference to array
-			(1 + SizeString) + SizeEmpty,
+			expectedSizeDiff: 1 + SizeEmpty,
+			// len("y") + reference to array
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty,
 		},
 		{
-			"reference to sparse array",
-			`x = []
+			desc: "reference to sparse array",
+			script: `x = []
 			x[5000] = "abcb";
 			x[5001] = "abc";
 			checkMem()
 			y = x;
 			// len("y") + reference to array
 			checkMem()`,
-			(1 + SizeString) + SizeEmpty,
+			expectedSizeDiff:    1 + SizeEmpty,
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty,
 		},
 		{
-			"Date object",
-			`
+			desc: "Date object",
+			script: `
 			d1 = new Date();
 			checkMem();
 			d2 = new Date();
 			checkMem()
 			`,
 			// len("d2") + size of msec + reference to visited base object + base object prototype reference
-			(2 + SizeString) + SizeNumber + SizeEmpty + SizeEmpty,
+			expectedSizeDiff: 2 + SizeNumber + SizeEmpty + SizeEmpty,
+			// len("d2") + size of msec + reference to visited base object + base object prototype reference
+			expectedNewSizeDiff: (2 + SizeString) + SizeNumber + SizeEmpty + SizeEmpty,
 		},
 		{
-			"Empty object",
-			`
+			desc: "Empty object",
+			script: `
 			checkMem();
 			o = {}
 			checkMem()
 			`,
 			// len("o") + object's starting size + reference to prototype
-			(1 + SizeString) + SizeEmpty + SizeNumber,
+			expectedSizeDiff: 1 + SizeEmpty + SizeNumber,
+			// len("o") + object's starting size + reference to prototype
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty + SizeNumber,
 		},
 		{
-			"Map",
-			`var m = new Map();
+			desc: "Map",
+			script: `var m = new Map();
 			m.set("first", 1);
 			checkMem();
 			m.set("abc", {"a":10, "b":"1234"});
 			checkMem();`,
-			3 + SizeString + // "abc"
+			expectedSizeDiff: 3 + // "abc"
+				SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				1 + SizeNumber + // "a" and number
+				1 + 4 + // "b" and "1234" string
+				// stack difference in going from
+				//	[..other, first, 1]
+				//  to
+				//	[..other, abc, [object Object], 1234]
+				2,
+			expectedNewSizeDiff: 3 + SizeString + // "abc"
 				SizeEmpty + SizeEmpty + // outer object + reference to its prototype
 				(1 + SizeString) + SizeNumber + // "a" and number
 				(1 + SizeString) + (4 + SizeString) + // "b" and "1234" string
@@ -282,8 +331,8 @@ func TestMemCheck(t *testing.T) {
 				18,
 		},
 		{
-			"Proxy",
-			`var target = {
+			desc: "Proxy",
+			script: `var target = {
 				message1: "hello",
 				message2: "everyone"
 			};
@@ -299,129 +348,169 @@ func TestMemCheck(t *testing.T) {
 			proxy2 = new Proxy(target, handler);
 			checkMem();
 			`,
-			(6 + SizeString) + // "proxy2"
+			expectedSizeDiff: 6 + // "proxy2"
 				SizeEmpty + // proxy overhead
 				SizeEmpty + SizeEmpty + // base object + prototype
 				SizeEmpty + // target object reference
 				SizeEmpty, // handler object reference
+			expectedNewSizeDiff: (6 + SizeString) + // "proxy2"
+				SizeEmpty + // proxy overhead
+				SizeEmpty + SizeEmpty + // base object + prototype
+				SizeEmpty + // target object reference
+				SizeEmpty, // handler object reference,
 		},
 		{
-			"String",
-			`str1 = new String("hi")
+			desc: "String",
+			script: `str1 = new String("hi")
 
 			checkMem();
 			str2 = new String("hello")
 			checkMem();
 			`,
-			(4 + SizeString) + // "str2"
-				(5 + SizeString) + // "hello"
+			expectedSizeDiff: 4 + // "str2"
+				5 + // "hello"
 				SizeEmpty + SizeEmpty + // base object + prototype
 				6 + SizeNumber, // "length" + number
+			expectedNewSizeDiff: (4 + SizeString) + // "str2"
+				(5 + SizeString) + // "hello"
+				SizeEmpty + SizeEmpty + // base object + prototype
+				(6 + SizeString) + SizeNumber, // "length" + number,
 		},
 		{
-			"Typed array",
-			`var ta = new Uint8Array(1);
+			desc: "Typed array",
+			script: `var ta = new Uint8Array(1);
 			checkMem();
 			ta2 = new Uint8Array([1, 2, 3, 4]);
 			checkMem();
 			`,
-			(3 + SizeString) + // "ta2"
+			expectedSizeDiff: 3 + // "ta2"
 				SizeEmpty + // typed array overhead
 				SizeEmpty + SizeEmpty + // base object + prototype
 				4 + SizeEmpty + SizeEmpty + // array buffer data +  base object + prototype
 				SizeEmpty + // default constructor
 				SizeInt, // last element (4) on stack
+			expectedNewSizeDiff: (3 + SizeString) + // "ta2"
+				SizeEmpty + // typed array overhead
+				SizeEmpty + SizeEmpty + // base object + prototype
+				4 + SizeEmpty + SizeEmpty + // array buffer data +  base object + prototype
+				SizeEmpty + // default constructor
+				SizeInt, // last element (4) on stack,
 		},
 		{
-			"ArrayBuffer",
-			`var buffer = new ArrayBuffer(16);
+			desc: "ArrayBuffer",
+			script: `var buffer = new ArrayBuffer(16);
 
 			checkMem();
 			buffer2 = new ArrayBuffer(16);
 			checkMem();`,
-			(7 + SizeString) + // "buffer2"
+			expectedSizeDiff: 7 + // "buffer2"
 				16 + // data size
 				SizeEmpty + SizeEmpty, // base object + prototype
+			expectedNewSizeDiff: (7 + SizeString) + // "buffer2"
+				16 + // data size
+				SizeEmpty + SizeEmpty, // base object + prototype,
 		},
 		{
-			"DataView",
-			`var buffer = new ArrayBuffer(16);
+			desc: "DataView",
+			script: `var buffer = new ArrayBuffer(16);
 			var view = new DataView(buffer, 0);
 			var buffer2 = new ArrayBuffer(16);
 
 			checkMem();
 			view2 = new DataView(buffer2, 0);
 			checkMem();`,
-			(5 + SizeString) + // "view2"
+			expectedSizeDiff: 5 + // "view2"
 				SizeEmpty + // DataView overhead
 				SizeEmpty + SizeEmpty + // base object + prototype
 				SizeEmpty, // array buffer reference
+			expectedNewSizeDiff: (5 + SizeString) + // "view2"
+				SizeEmpty + // DataView overhead
+				SizeEmpty + SizeEmpty + // base object + prototype
+				SizeEmpty, // array buffer reference,
 		},
 		{
-			"Number",
-			`num1 = new Number("1")
+			desc: "Number",
+			script: `num1 = new Number("1")
 
 			checkMem();
 			num2 = new Number("2")
 			checkMem();`,
-			(4 + SizeString) + // "num2"
+			expectedSizeDiff: 4 + // "num2"
 				SizeNumber +
 				SizeEmpty + SizeEmpty, // base object + prototype
+			expectedNewSizeDiff: (4 + SizeString) + // "num2"
+				SizeNumber +
+				SizeEmpty + SizeEmpty, // base object + prototype,
 		},
 		// TODO(REALMC-10739) add a test that calls Error.captureStackTrace when it is implemented)
 		{
-			"stash",
-			`checkMem();
+			desc: "stash",
+			script: `checkMem();
 			try {
 				throw new Error("abc");
 			} catch(e) {
 				checkMem();
 			}
 			`,
-			(7 + SizeString) + (3 + SizeString) + // Error "message" field + len("abc")
-				(4 + SizeString) + (5 + SizeString) + // Error "name" field + len("Error")
+			expectedSizeDiff: 7 + 3 + // Error "message" field + len("abc")
+				4 + 5 + // Error "name" field + len("Error")
 				SizeEmpty + SizeEmpty, // base object + prototype
+			expectedNewSizeDiff: (7 + SizeString) + (3 + SizeString) + // Error "message" field + len("abc")
+				(4 + SizeString) + (5 + SizeString) + // Error "name" field + len("Error")
+				SizeEmpty + SizeEmpty, // base object + prototype,
 		},
 		{
-			"Native value",
-			`checkMem();
+			desc: "Native value",
+			script: `checkMem();
 			nv = new MyNativeVal()
 			checkMem();`,
-			testNativeValueMemUsage +
-				(2 + SizeString), // "nv"
+			expectedSizeDiff: testNativeValueMemUsage +
+				2, // "nv"
+			expectedNewSizeDiff: testNativeValueMemUsage +
+				(2 + SizeString), // "nv",
 		},
 	} {
-		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
+		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			memChecks := []uint64{}
+			newMemChecks := []uint64{}
 			vm := New()
+
 			vm.Set("checkMem", func(call FunctionCall) Value {
-				mem, err := vm.MemUsage(
+				mem, newMem, err := vm.MemUsage(
 					NewMemUsageContext(vm, 100, memUsageLimit, arrLenThreshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
 				}
 				memChecks = append(memChecks, mem)
+				newMemChecks = append(newMemChecks, newMem)
 				return UndefinedValue()
 			})
 
 			nc := vm.CreateNativeClass("MyNativeVal", func(call FunctionCall) interface{} {
 				return TestNativeValue{}
 			}, nil, nil)
-
 			vm.Set("MyNativeVal", nc.Function)
 
 			_, err := vm.RunString(tc.script)
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			if len(memChecks) < 2 {
 				t.Fatalf("expected at least two entries in mem check function, but got %d", len(memChecks))
+			}
+			if len(newMemChecks) < 2 {
+				t.Fatalf("expected at least two entries in new mem check function, but got %d", len(memChecks))
 			}
 
 			memDiff := memChecks[len(memChecks)-1] - memChecks[0]
 			if memDiff != tc.expectedSizeDiff {
 				t.Fatalf("expected memory change to equal %d but got %d instead", tc.expectedSizeDiff, memDiff)
+			}
+			newMemDiff := newMemChecks[len(newMemChecks)-1] - newMemChecks[0]
+			if newMemDiff != tc.expectedNewSizeDiff {
+				t.Fatalf("expected new memory change to equal %d but got %d instead", tc.expectedNewSizeDiff, newMemDiff)
 			}
 		})
 	}
@@ -466,14 +555,14 @@ func TestMemMaxDepth(t *testing.T) {
 
 			// All global variables are contained in the Runtime's globalObject field, which causes
 			// them to be one level deeper
-			_, err = vm.MemUsage(
+			_, _, err = vm.MemUsage(
 				NewMemUsageContext(vm, tc.expectedDepth, memUsageLimit, arrLenThreshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
 			)
 			if err != ErrMaxDepth {
 				t.Fatalf("expected mem check to hit depth limit error, but got nil %v", err)
 			}
 
-			_, err = vm.MemUsage(
+			_, _, err = vm.MemUsage(
 				NewMemUsageContext(vm, tc.expectedDepth+1, memUsageLimit, arrLenThreshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
 			)
 			if err != nil {
@@ -485,15 +574,16 @@ func TestMemMaxDepth(t *testing.T) {
 
 func TestMemArraysWithLenThreshold(t *testing.T) {
 	for _, tc := range []struct {
-		description      string
-		script           string
-		threshold        int
-		memLimit         uint64
-		expectedSizeDiff uint64
+		desc                string
+		script              string
+		threshold           int
+		memLimit            uint64
+		expectedSizeDiff    uint64
+		expectedNewSizeDiff uint64
 	}{
 		{
-			"array of numbers under length threshold",
-			`y = []
+			desc: "array of numbers under length threshold",
+			script: `y = []
 			y.push([]);
 			let i=0;
 			checkMem();
@@ -501,14 +591,16 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				y[0].push(i);
 			};
 			checkMem()`,
-			100,
-			memUsageLimit,
-			SizeEmpty + // Array overhead
+			threshold: 100,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmpty + // Array overhead
 				20*SizeNumber, // size of property values
+			expectedNewSizeDiff: SizeEmpty + // Array overhead
+				20*SizeNumber, // size of property values,
 		},
 		{
-			"array of numbers over threshold",
-			`y = []
+			desc: "array of numbers over threshold",
+			script: `y = []
 			y.push([]);
 			let i=0;
 			checkMem();
@@ -516,14 +608,16 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				y[0].push(i);
 			};
 			checkMem()`,
-			100,
-			memUsageLimit,
-			SizeEmpty + // Array overhead
+			threshold: 100,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmpty + // Array overhead
 				200*SizeNumber, // size of property values
+			expectedNewSizeDiff: SizeEmpty + // Array overhead
+				200*SizeNumber, // size of property values,
 		},
 		{
-			"mixed array under threshold",
-			`y = []
+			desc: "mixed array under threshold",
+			script: `y = []
 			y.push([]);
 			let i = 0;
 			checkMem();
@@ -531,9 +625,16 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				y[0].push(i<50?0:true);
 			};
 			checkMem()`,
-			200,
-			memUsageLimit,
-			SizeEmpty + // Array overhead
+			threshold: 200,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmpty + // Array overhead
+				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
+			expectedNewSizeDiff: SizeEmpty + // Array overhead
 				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
@@ -542,8 +643,8 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				+1,
 		},
 		{
-			"array under threshold but over limit",
-			`y = []
+			desc: "array under threshold but over limit",
+			script: `y = []
 			y.push([]);
 			let i = 0;
 			checkMem();
@@ -551,14 +652,16 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				y[0].push(i);
 			};
 			checkMem()`,
-			200,
-			70,
+			threshold: 200,
+			// baseObject is 38 + 3*SizeNumber = 62, so at 60 we expect to exceed the limit
+			memLimit: 60,
 			// Array overhead, size of property values, only 3 values before we hit the mem limit
-			SizeEmpty + (3 * SizeNumber),
+			expectedSizeDiff:    SizeEmpty + (3 * SizeNumber),
+			expectedNewSizeDiff: SizeEmpty + (3 * SizeNumber),
 		},
 		{
-			"mixed array over threshold",
-			`y = []
+			desc: "mixed array over threshold",
+			script: `y = []
 			y.push([]);
 			let i = 0;
 			checkMem();
@@ -566,10 +669,16 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				y[0].push(i<50?0:true);
 			};
 			checkMem()`,
-			50,
-			memUsageLimit,
-			// Array overhead, size of property values
-			SizeEmpty + // Array overhead
+			threshold: 50,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmpty + // Array overhead
+				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
+			expectedNewSizeDiff: SizeEmpty + // Array overhead
 				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
@@ -578,8 +687,8 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				+1,
 		},
 		{
-			"mixed scattered array over threshold wcs",
-			`y = []
+			desc: "mixed scattered array over threshold wcs",
+			script: `y = []
 			y.push([]);
 			let i = 0;
 			checkMem();
@@ -587,9 +696,16 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				y[0].push(i%10==0?0:true);
 			};
 			checkMem()`,
-			50,
-			memUsageLimit,
-			SizeEmpty + // Array overhead,
+			threshold: 50,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmpty + // Array overhead,
+				(100 * SizeNumber) + // size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
+			expectedNewSizeDiff: SizeEmpty + // Array overhead,
 				(100 * SizeNumber) + // size of property values
 				// stack difference in going from
 				//	[..other, []]
@@ -598,24 +714,26 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				+1,
 		},
 	} {
-		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
+		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			memChecks := []uint64{}
+			newMemChecks := []uint64{}
 			vm := New()
+
 			vm.Set("checkMem", func(call FunctionCall) Value {
-				mem, err := vm.MemUsage(
+				mem, newMem, err := vm.MemUsage(
 					NewMemUsageContext(vm, 100, tc.memLimit, tc.threshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
 				}
 				memChecks = append(memChecks, mem)
+				newMemChecks = append(newMemChecks, newMem)
 				return UndefinedValue()
 			})
 
 			nc := vm.CreateNativeClass("MyNativeVal", func(call FunctionCall) interface{} {
 				return TestNativeValue{}
 			}, nil, nil)
-
 			vm.Set("MyNativeVal", nc.Function)
 
 			_, err := vm.RunString(tc.script)
@@ -625,10 +743,17 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			if len(memChecks) < 2 {
 				t.Fatalf("expected at least two entries in mem check function, but got %d", len(memChecks))
 			}
+			if len(newMemChecks) < 2 {
+				t.Fatalf("expected at least two entries in new mem check function, but got %d", len(newMemChecks))
+			}
 
 			memDiff := memChecks[len(memChecks)-1] - memChecks[0]
 			if memDiff != tc.expectedSizeDiff {
 				t.Fatalf("expected memory change to equal %d but got %d instead", tc.expectedSizeDiff, memDiff)
+			}
+			newMemDiff := newMemChecks[len(newMemChecks)-1] - newMemChecks[0]
+			if newMemDiff != tc.expectedNewSizeDiff {
+				t.Fatalf("expected new memory change to equal %d but got %d instead", tc.expectedNewSizeDiff, newMemDiff)
 			}
 		})
 	}
@@ -636,104 +761,123 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 
 func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 	for _, tc := range []struct {
-		description      string
-		script           string
-		threshold        int
-		memLimit         uint64
-		expectedSizeDiff uint64
+		desc                string
+		script              string
+		threshold           int
+		memLimit            uint64
+		expectedSizeDiff    uint64
+		expectedNewSizeDiff uint64
 	}{
 		{
-			"object under threshold",
-			`y = {}
+			desc: "object under threshold",
+			script: `y = {}
 			let i =0;
 			checkMem();
 			for (i=0;i<10;i++) {
 				y["i"+i] = i
 			}
 			checkMem()`,
-			100,
-			memUsageLimit,
+			threshold: 100,
+			memLimit:  memUsageLimit,
 			// object overhead + len("i0") + value i
-			SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
+			expectedSizeDiff: SizeEmpty + 10*2 + 10*SizeNumber,
+			// object overhead + len("i0") + value i
+			expectedNewSizeDiff: SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
-			"object under threshold but over limit",
-			`y = {}
+			desc: "object under threshold but over limit",
+			script: `y = {}
 			let i = 0;
 			checkMem();
 			for (i=0;i<10;i++) {
 				y["i"+i] = i
 			}
 			checkMem()`,
-			100,
-			40,
+			threshold: 100,
+			memLimit:  40,
 			// object overhead + len("i0") + value i
-			SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
+			expectedSizeDiff: SizeEmpty + 10*2 + 10*SizeNumber,
+			// object overhead + len("i0") + value i
+			expectedNewSizeDiff: SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
-			"object over threshold",
-			`y = {}
+			desc: "object over threshold",
+			script: `y = {}
 			let i = 0;
 			checkMem();
 			for (i=100;i<200;i++) {
 				y["i"+i] = i
 			}
 			checkMem()`,
-			75,
-			memUsageLimit,
+			threshold: 75,
+			memLimit:  memUsageLimit,
 			// object overhead + len("i100") + value i
-			SizeEmpty + 100*(4+SizeString) + 100*SizeNumber,
+			expectedSizeDiff: SizeEmpty + 100*4 + 100*SizeNumber,
+			// object overhead + len("i100") + value i
+			expectedNewSizeDiff: SizeEmpty + 100*(4+SizeString) + 100*SizeNumber,
 		},
 		{
-			"mixed object over threshold",
-			`y = {}
+			desc: "mixed object over threshold",
+			script: `y = {}
 			let i = 0;
 			checkMem();
 			for (i=100;i<200;i++) {
 				y["i"+i] = i < 150 ? i : "i"+i
 			}
 			checkMem()`,
-			200,
-			memUsageLimit,
+			threshold: 200,
+			memLimit:  memUsageLimit,
 			// object overhead + key len("i100") + value i for the items 100 to 149
-			SizeEmpty + 50*(4+SizeString) + 50*SizeNumber +
+			expectedSizeDiff: SizeEmpty + 50*4 + 50*SizeNumber +
+				// len("i150") + len("i150") for the items 150 to 199
+				50*4 + 50*4 +
+				// 150 number + len("i") in "i"+i expression
+				3 + 1,
+			// object overhead + key len("i100") + value i for the items 100 to 149
+			expectedNewSizeDiff: SizeEmpty + 50*(4+SizeString) + 50*SizeNumber +
 				// len("i150") + len("i150") for the items 150 to 199
 				50*(4+SizeString) + 50*(4+SizeString) +
 				// 150 number + len("i") in "i"+i expression
 				3 + (1 + SizeString),
 		},
 	} {
-		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
+		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			memChecks := []uint64{}
+			newMemChecks := []uint64{}
 			vm := New()
+
 			vm.Set("checkMem", func(call FunctionCall) Value {
-				mem, err := vm.MemUsage(
+				mem, newMem, err := vm.MemUsage(
 					NewMemUsageContext(vm, 100, tc.memLimit, arrLenThreshold, tc.threshold, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
 				}
 				memChecks = append(memChecks, mem)
+				newMemChecks = append(newMemChecks, newMem)
 				return UndefinedValue()
 			})
 
 			nc := vm.CreateNativeClass("MyNativeVal", func(call FunctionCall) interface{} {
 				return TestNativeValue{}
 			}, nil, nil)
-
 			vm.Set("MyNativeVal", nc.Function)
 
 			_, err := vm.RunString(tc.script)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(memChecks) < 2 {
-				t.Fatalf("expected at least two entries in mem check function, but got %d", len(memChecks))
+			if len(newMemChecks) < 2 {
+				t.Fatalf("expected at least two entries in new mem check function, but got %d", len(newMemChecks))
 			}
 
 			memDiff := memChecks[len(memChecks)-1] - memChecks[0]
 			if memDiff != tc.expectedSizeDiff {
 				t.Fatalf("expected memory change to equal %d but got %d instead", tc.expectedSizeDiff, memDiff)
+			}
+			newMemDiff := newMemChecks[len(newMemChecks)-1] - newMemChecks[0]
+			if newMemDiff != tc.expectedNewSizeDiff {
+				t.Fatalf("expected new memory change to equal %d but got %d instead", tc.expectedNewSizeDiff, newMemDiff)
 			}
 		})
 	}

--- a/memory_test.go
+++ b/memory_test.go
@@ -65,8 +65,8 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			x.push(null)
 			checkMem()`,
-			expectedSizeDiff:    SizeEmpty,
-			expectedNewSizeDiff: SizeEmpty,
+			expectedSizeDiff:    SizeEmptyStruct,
+			expectedNewSizeDiff: SizeEmptyStruct,
 		},
 		{
 			desc: "undefined",
@@ -75,8 +75,8 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			x.push(undefined)
 			checkMem()`,
-			expectedSizeDiff:    SizeEmpty,
-			expectedNewSizeDiff: SizeEmpty,
+			expectedSizeDiff:    SizeEmptyStruct,
+			expectedNewSizeDiff: SizeEmptyStruct,
 		},
 		{
 			desc: "string",
@@ -105,16 +105,16 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			y.push({"a":10, "b":"1234", "c":{}})
 			checkMem()`,
-			expectedSizeDiff: SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+			expectedSizeDiff: SizeEmptyStruct + SizeEmptyStruct + // outer object + reference to its prototype
 				1 + SizeNumber + // "a" and number 10
 				1 + 4 + // "b" and string "1234"
-				1 + SizeEmpty + SizeEmpty + //  "c" (object + prototype reference)
-				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
-			expectedNewSizeDiff: SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				1 + SizeEmptyStruct + SizeEmptyStruct + //  "c" (object + prototype reference)
+				SizeEmptyStruct, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
+			expectedNewSizeDiff: SizeEmptyStruct + SizeEmptyStruct + // outer object + reference to its prototype
 				(1 + SizeString) + SizeNumber + // "a" and number 10
 				(1 + SizeString) + (4 + SizeString) + // "b" and string "1234"
-				(1 + SizeString) + SizeEmpty + SizeEmpty + //  "c" (object + prototype reference)
-				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8),
+				(1 + SizeString) + SizeEmptyStruct + SizeEmptyStruct + //  "c" (object + prototype reference)
+				SizeEmptyStruct, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8),
 		},
 		{
 			desc: "array of numbers",
@@ -128,8 +128,8 @@ func TestMemCheck(t *testing.T) {
 			checkMem()`,
 			// Array overhead,
 			// size of property values,
-			expectedSizeDiff:    SizeEmpty + 20*SizeNumber,
-			expectedNewSizeDiff: SizeEmpty + 20*SizeNumber,
+			expectedSizeDiff:    SizeEmptyStruct + 20*SizeNumber,
+			expectedNewSizeDiff: SizeEmptyStruct + 20*SizeNumber,
 		},
 		{
 			desc: "overhead of a single new scope",
@@ -139,12 +139,12 @@ func TestMemCheck(t *testing.T) {
 			})();`, // over
 			expectedSizeDiff: emptyFunctionScopeOverhead +
 				functionStackOverhead + // anonymous function on stack
-				SizeEmpty, // undefined return on stack
+				SizeEmptyStruct, // undefined return on stack
 			expectedNewSizeDiff: emptyFunctionScopeOverhead +
 				functionStackOverhead + // anonymous function on stack
 				SizeString + // empty string for anon function name
 				SizeString + SizeString + // overhead of "name" and "length" props on function object
-				SizeEmpty, // undefined return on stack,
+				SizeEmptyStruct, // undefined return on stack,
 		},
 		{
 			desc: "previous function scopes should not affect the current memory",
@@ -153,9 +153,9 @@ func TestMemCheck(t *testing.T) {
 			})();
 			checkMem();`,
 			expectedSizeDiff: 0 +
-				SizeEmpty, // undefined return value on stack
+				SizeEmptyStruct, // undefined return value on stack
 			expectedNewSizeDiff: 0 +
-				SizeEmpty, // undefined return value on stack
+				SizeEmptyStruct, // undefined return value on stack
 		},
 		{
 			desc: "overhead of each scope is equivalent regardless of depth",
@@ -174,12 +174,12 @@ func TestMemCheck(t *testing.T) {
 				})();
 			})();`,
 			expectedSizeDiff: (6 * functionStackOverhead) + // anonymous functions on stack
-				(6 * SizeEmpty) + // undefined return value for each function on stack
+				(6 * SizeEmptyStruct) + // undefined return value for each function on stack
 				(6 * emptyFunctionScopeOverhead),
 			expectedNewSizeDiff: (6 * functionStackOverhead) + // anonymous functions on stack
 				(6 * SizeString) + // empty string for anon function name
 				(6 * (SizeString + SizeString)) + // overhead of "name" and "length" props on function object
-				(6 * SizeEmpty) + // undefined return value for each function on stack
+				(6 * SizeEmptyStruct) + // undefined return value for each function on stack
 				(6 * emptyFunctionScopeOverhead),
 		},
 		{
@@ -191,13 +191,13 @@ func TestMemCheck(t *testing.T) {
 			})();`,
 			// function overhead plus the number value of the "zzzx" property and its string name
 			expectedSizeDiff: emptyFunctionScopeOverhead + SizeNumber + functionStackOverhead +
-				SizeEmpty + // undefined return value on stack
+				SizeEmptyStruct + // undefined return value on stack
 				SizeNumber, // number 10 on stack
 			expectedNewSizeDiff: // function overhead plus the number value of the "zzzx" property and its string name
 			emptyFunctionScopeOverhead + SizeNumber + functionStackOverhead +
 				SizeString + // empty string for anon function name
 				SizeString + SizeString + // overhead of "name" and "length" props on function object
-				SizeEmpty + // undefined return value on stack
+				SizeEmptyStruct + // undefined return value on stack
 				SizeNumber, // number 10 on stack,
 		},
 		{
@@ -211,10 +211,10 @@ func TestMemCheck(t *testing.T) {
 			 zzza.y = zzzb
 			 zzzb.x = zzza
 			 checkMem()`,
-			expectedSizeDiff: 1 + SizeEmpty + // "x" property name + references to object
-				1 + SizeEmpty, // "y" property names + references to object
-			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty + // "x" property name + references to object
-				(1 + SizeString) + SizeEmpty, // "y" property names + references to object,
+			expectedSizeDiff: 1 + SizeEmptyStruct + // "x" property name + references to object
+				1 + SizeEmptyStruct, // "y" property names + references to object
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmptyStruct + // "x" property name + references to object
+				(1 + SizeString) + SizeEmptyStruct, // "y" property names + references to object,
 		},
 		{
 			desc: "sparse array with arrayObject",
@@ -263,9 +263,9 @@ func TestMemCheck(t *testing.T) {
 			y = x;
 			checkMem()`,
 			// len("y") + reference to array
-			expectedSizeDiff: 1 + SizeEmpty,
+			expectedSizeDiff: 1 + SizeEmptyStruct,
 			// len("y") + reference to array
-			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty,
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmptyStruct,
 		},
 		{
 			desc: "reference to sparse array",
@@ -276,8 +276,8 @@ func TestMemCheck(t *testing.T) {
 			y = x;
 			// len("y") + reference to array
 			checkMem()`,
-			expectedSizeDiff:    1 + SizeEmpty,
-			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty,
+			expectedSizeDiff:    1 + SizeEmptyStruct,
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmptyStruct,
 		},
 		{
 			desc: "Date object",
@@ -288,9 +288,9 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			`,
 			// len("d2") + size of msec + reference to visited base object + base object prototype reference
-			expectedSizeDiff: 2 + SizeNumber + SizeEmpty + SizeEmpty,
+			expectedSizeDiff: 2 + SizeNumber + SizeEmptyStruct + SizeEmptyStruct,
 			// len("d2") + size of msec + reference to visited base object + base object prototype reference
-			expectedNewSizeDiff: (2 + SizeString) + SizeNumber + SizeEmpty + SizeEmpty,
+			expectedNewSizeDiff: (2 + SizeString) + SizeNumber + SizeEmptyStruct + SizeEmptyStruct,
 		},
 		{
 			desc: "Empty object",
@@ -300,9 +300,9 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			`,
 			// len("o") + object's starting size + reference to prototype
-			expectedSizeDiff: 1 + SizeEmpty + SizeNumber,
+			expectedSizeDiff: 1 + SizeEmptyStruct + SizeNumber,
 			// len("o") + object's starting size + reference to prototype
-			expectedNewSizeDiff: (1 + SizeString) + SizeEmpty + SizeNumber,
+			expectedNewSizeDiff: (1 + SizeString) + SizeEmptyStruct + SizeNumber,
 		},
 		{
 			desc: "Map",
@@ -312,7 +312,7 @@ func TestMemCheck(t *testing.T) {
 			m.set("abc", {"a":10, "b":"1234"});
 			checkMem();`,
 			expectedSizeDiff: 3 + // "abc"
-				SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				SizeEmptyStruct + SizeEmptyStruct + // outer object + reference to its prototype
 				1 + SizeNumber + // "a" and number
 				1 + 4 + // "b" and "1234" string
 				// stack difference in going from
@@ -321,7 +321,7 @@ func TestMemCheck(t *testing.T) {
 				//	[..other, abc, [object Object], 1234]
 				2,
 			expectedNewSizeDiff: 3 + SizeString + // "abc"
-				SizeEmpty + SizeEmpty + // outer object + reference to its prototype
+				SizeEmptyStruct + SizeEmptyStruct + // outer object + reference to its prototype
 				(1 + SizeString) + SizeNumber + // "a" and number
 				(1 + SizeString) + (4 + SizeString) + // "b" and "1234" string
 				// stack difference in going from
@@ -349,15 +349,15 @@ func TestMemCheck(t *testing.T) {
 			checkMem();
 			`,
 			expectedSizeDiff: 6 + // "proxy2"
-				SizeEmpty + // proxy overhead
-				SizeEmpty + SizeEmpty + // base object + prototype
-				SizeEmpty + // target object reference
-				SizeEmpty, // handler object reference
+				SizeEmptyStruct + // proxy overhead
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
+				SizeEmptyStruct + // target object reference
+				SizeEmptyStruct, // handler object reference
 			expectedNewSizeDiff: (6 + SizeString) + // "proxy2"
-				SizeEmpty + // proxy overhead
-				SizeEmpty + SizeEmpty + // base object + prototype
-				SizeEmpty + // target object reference
-				SizeEmpty, // handler object reference,
+				SizeEmptyStruct + // proxy overhead
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
+				SizeEmptyStruct + // target object reference
+				SizeEmptyStruct, // handler object reference,
 		},
 		{
 			desc: "String",
@@ -369,11 +369,11 @@ func TestMemCheck(t *testing.T) {
 			`,
 			expectedSizeDiff: 4 + // "str2"
 				5 + // "hello"
-				SizeEmpty + SizeEmpty + // base object + prototype
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
 				6 + SizeNumber, // "length" + number
 			expectedNewSizeDiff: (4 + SizeString) + // "str2"
 				(5 + SizeString) + // "hello"
-				SizeEmpty + SizeEmpty + // base object + prototype
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
 				(6 + SizeString) + SizeNumber, // "length" + number,
 		},
 		{
@@ -384,16 +384,16 @@ func TestMemCheck(t *testing.T) {
 			checkMem();
 			`,
 			expectedSizeDiff: 3 + // "ta2"
-				SizeEmpty + // typed array overhead
-				SizeEmpty + SizeEmpty + // base object + prototype
-				4 + SizeEmpty + SizeEmpty + // array buffer data +  base object + prototype
-				SizeEmpty + // default constructor
+				SizeEmptyStruct + // typed array overhead
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
+				4 + SizeEmptyStruct + SizeEmptyStruct + // array buffer data +  base object + prototype
+				SizeEmptyStruct + // default constructor
 				SizeInt, // last element (4) on stack
 			expectedNewSizeDiff: (3 + SizeString) + // "ta2"
-				SizeEmpty + // typed array overhead
-				SizeEmpty + SizeEmpty + // base object + prototype
-				4 + SizeEmpty + SizeEmpty + // array buffer data +  base object + prototype
-				SizeEmpty + // default constructor
+				SizeEmptyStruct + // typed array overhead
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
+				4 + SizeEmptyStruct + SizeEmptyStruct + // array buffer data +  base object + prototype
+				SizeEmptyStruct + // default constructor
 				SizeInt, // last element (4) on stack,
 		},
 		{
@@ -405,10 +405,10 @@ func TestMemCheck(t *testing.T) {
 			checkMem();`,
 			expectedSizeDiff: 7 + // "buffer2"
 				16 + // data size
-				SizeEmpty + SizeEmpty, // base object + prototype
+				SizeEmptyStruct + SizeEmptyStruct, // base object + prototype
 			expectedNewSizeDiff: (7 + SizeString) + // "buffer2"
 				16 + // data size
-				SizeEmpty + SizeEmpty, // base object + prototype,
+				SizeEmptyStruct + SizeEmptyStruct, // base object + prototype,
 		},
 		{
 			desc: "DataView",
@@ -420,13 +420,13 @@ func TestMemCheck(t *testing.T) {
 			view2 = new DataView(buffer2, 0);
 			checkMem();`,
 			expectedSizeDiff: 5 + // "view2"
-				SizeEmpty + // DataView overhead
-				SizeEmpty + SizeEmpty + // base object + prototype
-				SizeEmpty, // array buffer reference
+				SizeEmptyStruct + // DataView overhead
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
+				SizeEmptyStruct, // array buffer reference
 			expectedNewSizeDiff: (5 + SizeString) + // "view2"
-				SizeEmpty + // DataView overhead
-				SizeEmpty + SizeEmpty + // base object + prototype
-				SizeEmpty, // array buffer reference,
+				SizeEmptyStruct + // DataView overhead
+				SizeEmptyStruct + SizeEmptyStruct + // base object + prototype
+				SizeEmptyStruct, // array buffer reference,
 		},
 		{
 			desc: "Number",
@@ -437,10 +437,10 @@ func TestMemCheck(t *testing.T) {
 			checkMem();`,
 			expectedSizeDiff: 4 + // "num2"
 				SizeNumber +
-				SizeEmpty + SizeEmpty, // base object + prototype
+				SizeEmptyStruct + SizeEmptyStruct, // base object + prototype
 			expectedNewSizeDiff: (4 + SizeString) + // "num2"
 				SizeNumber +
-				SizeEmpty + SizeEmpty, // base object + prototype,
+				SizeEmptyStruct + SizeEmptyStruct, // base object + prototype,
 		},
 		// TODO(REALMC-10739) add a test that calls Error.captureStackTrace when it is implemented)
 		{
@@ -454,10 +454,10 @@ func TestMemCheck(t *testing.T) {
 			`,
 			expectedSizeDiff: 7 + 3 + // Error "message" field + len("abc")
 				4 + 5 + // Error "name" field + len("Error")
-				SizeEmpty + SizeEmpty, // base object + prototype
+				SizeEmptyStruct + SizeEmptyStruct, // base object + prototype
 			expectedNewSizeDiff: (7 + SizeString) + (3 + SizeString) + // Error "message" field + len("abc")
 				(4 + SizeString) + (5 + SizeString) + // Error "name" field + len("Error")
-				SizeEmpty + SizeEmpty, // base object + prototype,
+				SizeEmptyStruct + SizeEmptyStruct, // base object + prototype,
 		},
 		{
 			desc: "Native value",
@@ -593,9 +593,9 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			threshold: 100,
 			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmpty + // Array overhead
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
 				20*SizeNumber, // size of property values
-			expectedNewSizeDiff: SizeEmpty + // Array overhead
+			expectedNewSizeDiff: SizeEmptyStruct + // Array overhead
 				20*SizeNumber, // size of property values,
 		},
 		{
@@ -610,9 +610,9 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			threshold: 100,
 			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmpty + // Array overhead
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
 				200*SizeNumber, // size of property values
-			expectedNewSizeDiff: SizeEmpty + // Array overhead
+			expectedNewSizeDiff: SizeEmptyStruct + // Array overhead
 				200*SizeNumber, // size of property values,
 		},
 		{
@@ -627,14 +627,14 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			threshold: 200,
 			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmpty + // Array overhead
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
 				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
 				//  to
 				//	[..other, true, 50]
 				+1,
-			expectedNewSizeDiff: SizeEmpty + // Array overhead
+			expectedNewSizeDiff: SizeEmptyStruct + // Array overhead
 				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
@@ -656,8 +656,8 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			// baseObject is 38 + 3*SizeNumber = 62, so at 60 we expect to exceed the limit
 			memLimit: 60,
 			// Array overhead, size of property values, only 3 values before we hit the mem limit
-			expectedSizeDiff:    SizeEmpty + (3 * SizeNumber),
-			expectedNewSizeDiff: SizeEmpty + (3 * SizeNumber),
+			expectedSizeDiff:    SizeEmptyStruct + (3 * SizeNumber),
+			expectedNewSizeDiff: SizeEmptyStruct + (3 * SizeNumber),
 		},
 		{
 			desc: "mixed array over threshold",
@@ -671,14 +671,14 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			threshold: 50,
 			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmpty + // Array overhead
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
 				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
 				//  to
 				//	[..other, true, 50]
 				+1,
-			expectedNewSizeDiff: SizeEmpty + // Array overhead
+			expectedNewSizeDiff: SizeEmptyStruct + // Array overhead
 				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
@@ -698,14 +698,14 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			threshold: 50,
 			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmpty + // Array overhead,
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead,
 				(100 * SizeNumber) + // size of property values
 				// stack difference in going from
 				//	[..other, []]
 				//  to
 				//	[..other, true, 50]
 				+1,
-			expectedNewSizeDiff: SizeEmpty + // Array overhead,
+			expectedNewSizeDiff: SizeEmptyStruct + // Array overhead,
 				(100 * SizeNumber) + // size of property values
 				// stack difference in going from
 				//	[..other, []]
@@ -780,9 +780,9 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			threshold: 100,
 			memLimit:  memUsageLimit,
 			// object overhead + len("i0") + value i
-			expectedSizeDiff: SizeEmpty + 10*2 + 10*SizeNumber,
+			expectedSizeDiff: SizeEmptyStruct + 10*2 + 10*SizeNumber,
 			// object overhead + len("i0") + value i
-			expectedNewSizeDiff: SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
+			expectedNewSizeDiff: SizeEmptyStruct + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
 			desc: "object under threshold but over limit",
@@ -796,9 +796,9 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			threshold: 100,
 			memLimit:  40,
 			// object overhead + len("i0") + value i
-			expectedSizeDiff: SizeEmpty + 10*2 + 10*SizeNumber,
+			expectedSizeDiff: SizeEmptyStruct + 10*2 + 10*SizeNumber,
 			// object overhead + len("i0") + value i
-			expectedNewSizeDiff: SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
+			expectedNewSizeDiff: SizeEmptyStruct + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
 			desc: "object over threshold",
@@ -812,9 +812,9 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			threshold: 75,
 			memLimit:  memUsageLimit,
 			// object overhead + len("i100") + value i
-			expectedSizeDiff: SizeEmpty + 100*4 + 100*SizeNumber,
+			expectedSizeDiff: SizeEmptyStruct + 100*4 + 100*SizeNumber,
 			// object overhead + len("i100") + value i
-			expectedNewSizeDiff: SizeEmpty + 100*(4+SizeString) + 100*SizeNumber,
+			expectedNewSizeDiff: SizeEmptyStruct + 100*(4+SizeString) + 100*SizeNumber,
 		},
 		{
 			desc: "mixed object over threshold",
@@ -828,13 +828,13 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			threshold: 200,
 			memLimit:  memUsageLimit,
 			// object overhead + key len("i100") + value i for the items 100 to 149
-			expectedSizeDiff: SizeEmpty + 50*4 + 50*SizeNumber +
+			expectedSizeDiff: SizeEmptyStruct + 50*4 + 50*SizeNumber +
 				// len("i150") + len("i150") for the items 150 to 199
 				50*4 + 50*4 +
 				// 150 number + len("i") in "i"+i expression
 				3 + 1,
 			// object overhead + key len("i100") + value i for the items 100 to 149
-			expectedNewSizeDiff: SizeEmpty + 50*(4+SizeString) + 50*SizeNumber +
+			expectedNewSizeDiff: SizeEmptyStruct + 50*(4+SizeString) + 50*SizeNumber +
 				// len("i150") + len("i150") for the items 150 to 199
 				50*(4+SizeString) + 50*(4+SizeString) +
 				// 150 number + len("i") in "i"+i expression

--- a/memory_test.go
+++ b/memory_test.go
@@ -518,35 +518,35 @@ func TestMemCheck(t *testing.T) {
 
 func TestMemMaxDepth(t *testing.T) {
 	for _, tc := range []struct {
-		description   string
+		desc          string
 		script        string
 		expectedDepth int
 	}{
 		{
-			"nested objects",
-			`var x = {"1": {"2": {"3": {"4": {"5": {"6": "abc"}}}}}}`,
-			6,
+			desc:          "nested objects",
+			script:        `var x = {"1": {"2": {"3": {"4": {"5": {"6": "abc"}}}}}}`,
+			expectedDepth: 6,
 		},
 		{
-			"array",
-			`var x = []
+			desc: "array",
+			script: `var x = []
 			x[1] = {"1": {"2": {"3": {"4": {"5": {"6": "abc"}}}}}};`,
-			7,
+			expectedDepth: 7,
 		},
 		{
-			"sparse array (sparseArrayObject)",
-			`var x = []
+			desc: "sparse array (sparseArrayObject)",
+			script: `var x = []
 			x[5000] = {"1": {"2": {"3": {"4": {"5": {"6": "abc"}}}}}};`,
-			7,
+			expectedDepth: 7,
 		},
 		{
-			"Map",
-			`var abc = new Map()
+			desc: "Map",
+			script: `var abc = new Map()
 			abc.set("obj", {"1": {"2": {"3": {"4": {"5": {"6": "abc"}}}}}});`,
-			7,
+			expectedDepth: 7,
 		},
 	} {
-		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
+		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			vm := New()
 			_, err := vm.RunString(tc.script)
 			if err != nil {

--- a/memory_test.go
+++ b/memory_test.go
@@ -80,7 +80,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			x.push("12345")
 			checkMem()`,
-			5,
+			5 + SizeString,
 		},
 		{
 			"string with multi-byte characters",
@@ -89,7 +89,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			x.push("\u2318")
 			checkMem()`,
-			3, // single char with 3-byte width
+			3 + SizeString, // single char with 3-byte width
 		},
 		{
 			"nested objects",
@@ -99,9 +99,9 @@ func TestMemCheck(t *testing.T) {
 			y.push({"a":10, "b":"1234", "c":{}})
 			checkMem()`,
 			SizeEmpty + SizeEmpty + // outer object + reference to its prototype
-				(1 + SizeNumber) + // "a" and number
-				(1 + 4) + // "b" and string
-				(1 + SizeEmpty + SizeEmpty) + //  "c" (object + prototype reference)
+				(1 + SizeString) + SizeNumber + // "a" and number 10
+				(1 + SizeString) + (4 + SizeString) + // "b" and string "1234"
+				(1 + SizeString) + SizeEmpty + SizeEmpty + //  "c" (object + prototype reference)
 				SizeEmpty, // stack difference from popping null(8) and then adding outer obj(8) + "c" obj (8)
 		},
 		{
@@ -126,6 +126,8 @@ func TestMemCheck(t *testing.T) {
 			})();`, // over
 			emptyFunctionScopeOverhead +
 				functionStackOverhead + // anonymous function on stack
+				SizeString + // empty string for anon function name
+				SizeString + SizeString + // overhead of "name" and "length" props on function object
 				SizeEmpty, // undefined return on stack
 		},
 		{
@@ -154,6 +156,8 @@ func TestMemCheck(t *testing.T) {
 				})();
 			})();`,
 			(6 * functionStackOverhead) + // anonymous functions on stack
+				(6 * SizeString) + // empty string for anon function name
+				(6 * (SizeString + SizeString)) + // overhead of "name" and "length" props on function object
 				(6 * SizeEmpty) + // undefined return value for each function on stack
 				(6 * emptyFunctionScopeOverhead),
 		},
@@ -166,6 +170,8 @@ func TestMemCheck(t *testing.T) {
 			})();`,
 			// function overhead plus the number value of the "zzzx" property and its string name
 			emptyFunctionScopeOverhead + SizeNumber + functionStackOverhead +
+				SizeString + // empty string for anon function name
+				SizeString + SizeString + // overhead of "name" and "length" props on function object
 				SizeEmpty + // undefined return value on stack
 				SizeNumber, // number 10 on stack
 		},
@@ -180,7 +186,8 @@ func TestMemCheck(t *testing.T) {
 			 zzza.y = zzzb
 			 zzzb.x = zzza
 			 checkMem()`,
-			2 + SizeEmpty + SizeEmpty, // "x" and "y" property names + references to each object
+			(1 + SizeString) + SizeEmpty + // "x" property name + references to object
+				(1 + SizeString) + SizeEmpty, // "y" property names + references to object
 		},
 		{
 			"sparse array with arrayObject",
@@ -189,7 +196,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			x[10] = "abc";
 			checkMem()`,
-			2, // 3 -> "abc" added to global memory | -1 difference on stack betwen "abc" and  "abcd"
+			2 + SizeString, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd"
 		},
 		{
 			"sparse array with sparseArrayObject",
@@ -199,7 +206,7 @@ func TestMemCheck(t *testing.T) {
 			x[5001] = "abc";
 			checkMem()`,
 			SizeInt32 +
-				2, // 3 -> "abc" added to global memory | -1 difference on stack betwen "abc" and  "abcd"
+				2 + SizeString, // 3 -> "abc" added to global memory | -1 difference on stack between "abc" and  "abcd"
 		},
 		{
 			"array with non-numeric keys",
@@ -210,8 +217,9 @@ func TestMemCheck(t *testing.T) {
 			x[1] = 3;
 			checkMem()
 			`,
-			// len("abc") + len("a") + SizeNumber
-			3 + 1 + SizeNumber,
+			1 + SizeString + // len("a")
+				3 + SizeString + // len("abc")
+				SizeNumber, // number 3
 		},
 		{
 			"reference to array",
@@ -222,7 +230,7 @@ func TestMemCheck(t *testing.T) {
 			y = x;
 			checkMem()`,
 			// len("y") + reference to array
-			1 + SizeEmpty,
+			(1 + SizeString) + SizeEmpty,
 		},
 		{
 			"reference to sparse array",
@@ -233,7 +241,7 @@ func TestMemCheck(t *testing.T) {
 			y = x;
 			// len("y") + reference to array
 			checkMem()`,
-			1 + SizeEmpty,
+			(1 + SizeString) + SizeEmpty,
 		},
 		{
 			"Date object",
@@ -244,7 +252,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			`,
 			// len("d2") + size of msec + reference to visited base object + base object prototype reference
-			2 + SizeNumber + SizeEmpty + SizeEmpty,
+			(2 + SizeString) + SizeNumber + SizeEmpty + SizeEmpty,
 		},
 		{
 			"Empty object",
@@ -254,20 +262,24 @@ func TestMemCheck(t *testing.T) {
 			checkMem()
 			`,
 			// len("o") + object's starting size + reference to prototype
-			1 + SizeEmpty + SizeNumber,
+			(1 + SizeString) + SizeEmpty + SizeNumber,
 		},
 		{
 			"Map",
 			`var m = new Map();
-			m.set("a", 1);
+			m.set("first", 1);
 			checkMem();
 			m.set("abc", {"a":10, "b":"1234"});
 			checkMem();`,
-			3 + // "abc"
+			3 + SizeString + // "abc"
 				SizeEmpty + SizeEmpty + // outer object + reference to its prototype
-				(1 + SizeNumber) + // "a" and number
-				(1 + 4) + // "b" and "1234" string
-				6, // stack difference
+				(1 + SizeString) + SizeNumber + // "a" and number
+				(1 + SizeString) + (4 + SizeString) + // "b" and "1234" string
+				// stack difference in going from
+				//	[..other, first, 1]
+				//  to
+				//	[..other, abc, [object Object], 1234]
+				18,
 		},
 		{
 			"Proxy",
@@ -287,7 +299,7 @@ func TestMemCheck(t *testing.T) {
 			proxy2 = new Proxy(target, handler);
 			checkMem();
 			`,
-			6 + // "proxy2"
+			(6 + SizeString) + // "proxy2"
 				SizeEmpty + // proxy overhead
 				SizeEmpty + SizeEmpty + // base object + prototype
 				SizeEmpty + // target object reference
@@ -301,8 +313,8 @@ func TestMemCheck(t *testing.T) {
 			str2 = new String("hello")
 			checkMem();
 			`,
-			4 + // "str2"
-				5 + // "hello"
+			(4 + SizeString) + // "str2"
+				(5 + SizeString) + // "hello"
 				SizeEmpty + SizeEmpty + // base object + prototype
 				6 + SizeNumber, // "length" + number
 		},
@@ -313,7 +325,7 @@ func TestMemCheck(t *testing.T) {
 			ta2 = new Uint8Array([1, 2, 3, 4]);
 			checkMem();
 			`,
-			3 + // "ta2"
+			(3 + SizeString) + // "ta2"
 				SizeEmpty + // typed array overhead
 				SizeEmpty + SizeEmpty + // base object + prototype
 				4 + SizeEmpty + SizeEmpty + // array buffer data +  base object + prototype
@@ -327,7 +339,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem();
 			buffer2 = new ArrayBuffer(16);
 			checkMem();`,
-			7 + // "buffer2"
+			(7 + SizeString) + // "buffer2"
 				16 + // data size
 				SizeEmpty + SizeEmpty, // base object + prototype
 		},
@@ -340,7 +352,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem();
 			view2 = new DataView(buffer2, 0);
 			checkMem();`,
-			5 + // "view2"
+			(5 + SizeString) + // "view2"
 				SizeEmpty + // DataView overhead
 				SizeEmpty + SizeEmpty + // base object + prototype
 				SizeEmpty, // array buffer reference
@@ -352,7 +364,7 @@ func TestMemCheck(t *testing.T) {
 			checkMem();
 			num2 = new Number("2")
 			checkMem();`,
-			4 + // "num2"
+			(4 + SizeString) + // "num2"
 				SizeNumber +
 				SizeEmpty + SizeEmpty, // base object + prototype
 		},
@@ -366,8 +378,8 @@ func TestMemCheck(t *testing.T) {
 				checkMem();
 			}
 			`,
-			7 + 3 + // Error "message" field + len("abc")
-				4 + 5 + // Error "name" field + len("Error")
+			(7 + SizeString) + (3 + SizeString) + // Error "message" field + len("abc")
+				(4 + SizeString) + (5 + SizeString) + // Error "name" field + len("Error")
 				SizeEmpty + SizeEmpty, // base object + prototype
 		},
 		{
@@ -375,7 +387,8 @@ func TestMemCheck(t *testing.T) {
 			`checkMem();
 			nv = new MyNativeVal()
 			checkMem();`,
-			testNativeValueMemUsage + 2,
+			testNativeValueMemUsage +
+				(2 + SizeString), // "nv"
 		},
 	} {
 		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
@@ -481,8 +494,8 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 		{
 			"array of numbers under length threshold",
 			`y = []
-			var i = 0;
 			y.push([]);
+			let i=0;
 			checkMem();
 			for(i=0;i<20;i++){
 				y[0].push(i);
@@ -490,29 +503,29 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			100,
 			memUsageLimit,
-			// Array overhead,
-			// size of property values,
-			SizeEmpty + 20*SizeNumber,
+			SizeEmpty + // Array overhead
+				20*SizeNumber, // size of property values
 		},
 		{
 			"array of numbers over threshold",
 			`y = []
-			var j = 0;
 			y.push([]);
+			let i=0;
 			checkMem();
 			for(i=0;i<200;i++){
-				y[0].push(j);
+				y[0].push(i);
 			};
 			checkMem()`,
 			100,
 			memUsageLimit,
-			// len("j") + value 0 + Array overhead + estimate of property values
-			1 + SizeNumber + SizeEmpty + 200*SizeNumber,
+			SizeEmpty + // Array overhead
+				200*SizeNumber, // size of property values
 		},
 		{
 			"mixed array under threshold",
 			`y = []
 			y.push([]);
+			let i = 0;
 			checkMem();
 			for(i=0;i<100;i++){
 				y[0].push(i<50?0:true);
@@ -520,27 +533,34 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			200,
 			memUsageLimit,
-			// Array overhead, size of property values
-			2 + SizeEmpty + SizeNumber + (50 * SizeNumber) + (50 * SizeBool),
+			SizeEmpty + // Array overhead
+				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
 		},
 		{
 			"array under threshold but over limit",
 			`y = []
 			y.push([]);
+			let i = 0;
 			checkMem();
 			for(i=0;i<10;i++){
-				y[0].push(true);
+				y[0].push(i);
 			};
 			checkMem()`,
 			200,
-			40,
+			70,
 			// Array overhead, size of property values, only 3 values before we hit the mem limit
-			2 + SizeEmpty + (3 * SizeBool),
+			SizeEmpty + (3 * SizeNumber),
 		},
 		{
 			"mixed array over threshold",
 			`y = []
 			y.push([]);
+			let i = 0;
 			checkMem();
 			for(i=0;i<100;i++){
 				y[0].push(i<50?0:true);
@@ -549,12 +569,19 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			50,
 			memUsageLimit,
 			// Array overhead, size of property values
-			2 + SizeEmpty + SizeNumber + (50 * SizeNumber) + (50 * SizeBool),
+			SizeEmpty + // Array overhead
+				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
 		},
 		{
 			"mixed scattered array over threshold wcs",
 			`y = []
 			y.push([]);
+			let i = 0;
 			checkMem();
 			for(i=0;i < 100;i++){
 				y[0].push(i%10==0?0:true);
@@ -562,8 +589,13 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 			checkMem()`,
 			50,
 			memUsageLimit,
-			// Array overhead, size of property values
-			2 + SizeEmpty + SizeNumber + (100 * SizeNumber),
+			SizeEmpty + // Array overhead,
+				(100 * SizeNumber) + // size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
 		},
 	} {
 		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {
@@ -613,36 +645,35 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 		{
 			"object under threshold",
 			`y = {}
-				checkMem();
-				for (i=0;i<10;i++) {
-					y["i"+i] = i
-				}
-				checkMem()`,
+			let i =0;
+			checkMem();
+			for (i=0;i<10;i++) {
+				y["i"+i] = i
+			}
+			checkMem()`,
 			100,
 			memUsageLimit,
-			// len("i0") + value i
-			10*2 + 10*SizeNumber +
-				// for loop 0 + 10 + len("i")
-				SizeNumber + SizeNumber + 1,
+			// object overhead + len("i0") + value i
+			SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
 			"object under threshold but over limit",
 			`y = {}
-				checkMem();
-				for (i=0;i<10;i++) {
-					y["i"+i] = i
-				}
-				checkMem()`,
+			let i = 0;
+			checkMem();
+			for (i=0;i<10;i++) {
+				y["i"+i] = i
+			}
+			checkMem()`,
 			100,
 			40,
-			// len("i0") + value i
-			10*2 + 10*SizeNumber +
-				// for loop 0 + 10 + len("i")
-				SizeNumber + SizeNumber + 1,
+			// object overhead + len("i0") + value i
+			SizeEmpty + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
 			"object over threshold",
 			`y = {}
+			let i = 0;
 			checkMem();
 			for (i=100;i<200;i++) {
 				y["i"+i] = i
@@ -650,14 +681,13 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			checkMem()`,
 			75,
 			memUsageLimit,
-			// len("i100") + value i
-			100*4 + 100*SizeNumber +
-				// for loop 100 + 200 + len("i")
-				SizeNumber + SizeNumber + 1,
+			// object overhead + len("i100") + value i
+			SizeEmpty + 100*(4+SizeString) + 100*SizeNumber,
 		},
 		{
 			"mixed object over threshold",
 			`y = {}
+			let i = 0;
 			checkMem();
 			for (i=100;i<200;i++) {
 				y["i"+i] = i < 150 ? i : "i"+i
@@ -665,12 +695,12 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			checkMem()`,
 			200,
 			memUsageLimit,
-			// len("i100") + value i
-			50*4 + 50*SizeNumber +
-				// len("i150") + len("i150") + 150 number + len("i")
-				50*4 + 50*4 + 3 + 1 +
-				// for loop 100 + 200 + len("i")
-				SizeNumber + SizeNumber + 1,
+			// object overhead + key len("i100") + value i for the items 100 to 149
+			SizeEmpty + 50*(4+SizeString) + 50*SizeNumber +
+				// len("i150") + len("i150") for the items 150 to 199
+				50*(4+SizeString) + 50*(4+SizeString) +
+				// 150 number + len("i") in "i"+i expression
+				3 + (1 + SizeString),
 		},
 	} {
 		t.Run(fmt.Sprintf(tc.description), func(t *testing.T) {

--- a/object.go
+++ b/object.go
@@ -1924,17 +1924,22 @@ func (i *privateId) string() unistring.String {
 	return privateIdString(i.name)
 }
 
+func computeMemUsageEstimate(memUsage, samplesVisited uint64, totalProps int) uint64 {
+	// averageMemUsage * total object props
+	return uint64(float32(memUsage) / float32(samplesVisited) * float32(totalProps))
+}
+
 // estimateMemUsage helps calculating mem usage for large objects.
 // It will sample the object and use those samples to estimate the
 // mem usage.
 func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	var samplesVisited uint64
-	var averageMemUsage, newAverageMemUsage float32
-	sampleSize := len(o.propNames) / 10
+	totalProps := len(o.propNames)
+	sampleSize := totalProps / 10
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions
-	for i := 0; i < len(o.propNames); i += sampleSize {
+	for i := 0; i < totalProps; i += sampleSize {
 		k := o.propNames[i]
 		memUsage += uint64(len(k))
 		newMemUsage += uint64(len(k)) + SizeString
@@ -1947,14 +1952,12 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, ne
 		samplesVisited += 1
 		memUsage += inc
 		newMemUsage += newInc
-		averageMemUsage = float32(memUsage) / float32(samplesVisited)
-		newAverageMemUsage = float32(newMemUsage) / float32(samplesVisited)
 		if err != nil {
-			return uint64(averageMemUsage * float32(len(o.propNames))), uint64(newAverageMemUsage * float32(len(o.propNames))), err
+			return computeMemUsageEstimate(memUsage, samplesVisited, totalProps), computeMemUsageEstimate(newMemUsage, samplesVisited, totalProps), err
 		}
 	}
 
-	return uint64(averageMemUsage * float32(len(o.propNames))), uint64(newAverageMemUsage * float32(len(o.propNames))), nil
+	return computeMemUsageEstimate(memUsage, samplesVisited, totalProps), computeMemUsageEstimate(newMemUsage, samplesVisited, totalProps), nil
 }
 
 func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {

--- a/object.go
+++ b/object.go
@@ -1962,7 +1962,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, ne
 
 func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(o)
 
@@ -1970,8 +1970,8 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsag
 		return 0, 0, err
 	}
 
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 	if ctx.ObjectPropsLenExceedsThreshold(len(o.propNames)) {
 		inc, newInc, err := o.estimateMemUsage(ctx)
 		memUsage += inc
@@ -2013,7 +2013,7 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsag
 
 func (o *primitiveValueObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(o)
 

--- a/object.go
+++ b/object.go
@@ -267,7 +267,7 @@ type objectImpl interface {
 	_putSym(s *Symbol, prop Value)
 	getPrivateEnv(typ *privateEnvType, create bool) *privateElements
 
-	MemUsage(ctx *MemUsageContext) (uint64, error)
+	MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error)
 }
 
 type baseObject struct {

--- a/object.go
+++ b/object.go
@@ -1944,7 +1944,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
 		inc, err := v.MemUsage(ctx)
 		samplesVisited += 1
 		total += inc
-		total += uint64(len(k))
+		total += uint64(len(k)) + SizeString
 		averageMemUsage = float32(total) / float32(samplesVisited)
 		if err != nil {
 			return uint64(averageMemUsage * float32(len(o.propNames))), err
@@ -1980,7 +1980,7 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
 
 			inc, err := v.MemUsage(ctx)
 			total += inc
-			total += uint64(len(k))
+			total += uint64(len(k)) + SizeString
 
 			if err != nil {
 				return total, err

--- a/object.go
+++ b/object.go
@@ -1927,97 +1927,103 @@ func (i *privateId) string() unistring.String {
 // estimateMemUsage helps calculating mem usage for large objects.
 // It will sample the object and use those samples to estimate the
 // mem usage.
-func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (uint64, error) {
-	var total, samplesVisited uint64
-	var averageMemUsage float32
+func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	var samplesVisited uint64
+	var averageMemUsage, newAverageMemUsage float32
 	sampleSize := len(o.propNames) / 10
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions
 	for i := 0; i < len(o.propNames); i += sampleSize {
 		k := o.propNames[i]
+		memUsage += uint64(len(k))
+		newMemUsage += uint64(len(k)) + SizeString
 		v := o.values[k]
 		if v == nil {
 			continue
 		}
 
-		inc, err := v.MemUsage(ctx)
+		inc, newInc, err := v.MemUsage(ctx)
 		samplesVisited += 1
-		total += inc
-		total += uint64(len(k)) + SizeString
-		averageMemUsage = float32(total) / float32(samplesVisited)
+		memUsage += inc
+		newMemUsage += newInc
+		averageMemUsage = float32(memUsage) / float32(samplesVisited)
+		newAverageMemUsage = float32(newMemUsage) / float32(samplesVisited)
 		if err != nil {
-			return uint64(averageMemUsage * float32(len(o.propNames))), err
+			return uint64(averageMemUsage * float32(len(o.propNames))), uint64(newAverageMemUsage * float32(len(o.propNames))), err
 		}
 	}
 
-	return uint64(averageMemUsage * float32(len(o.propNames))), nil
+	return uint64(averageMemUsage * float32(len(o.propNames))), uint64(newAverageMemUsage * float32(len(o.propNames))), nil
 }
 
-func (o *baseObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(o)
 
 	if err := ctx.Descend(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	total := SizeEmpty
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
 	if ctx.ObjectPropsLenExceedsThreshold(len(o.propNames)) {
-		inc, err := o.estimateMemUsage(ctx)
-		total += inc
+		inc, newInc, err := o.estimateMemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	} else {
 		for _, k := range o.propNames {
 			v := o.values[k]
+			memUsage += uint64(len(k))
+			newMemUsage += uint64(len(k)) + SizeString
+
 			if v == nil {
 				continue
 			}
-
-			inc, err := v.MemUsage(ctx)
-			total += inc
-			total += uint64(len(k)) + SizeString
-
+			inc, newInc, err := v.MemUsage(ctx)
+			memUsage += inc
+			newMemUsage += newInc
 			if err != nil {
-				return total, err
+				return memUsage, newMemUsage, err
 			}
 		}
 	}
 
 	if o.prototype != nil {
-		inc, err := o.prototype.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := o.prototype.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	ctx.Ascend()
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
-func (self *primitiveValueObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	if self == nil || ctx.IsObjVisited(self) {
-		return SizeEmpty, nil
+func (o *primitiveValueObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if o == nil || ctx.IsObjVisited(o) {
+		return SizeEmpty, SizeEmpty, nil
 	}
-	ctx.VisitObj(self)
+	ctx.VisitObj(o)
 
-	total := uint64(0)
-
-	if self.pValue != nil {
-		inc, err := self.pValue.MemUsage(ctx)
-		total += inc
+	if o.pValue != nil {
+		inc, newInc, err := o.pValue.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	inc, baseErr := self.baseObject.MemUsage(ctx)
-	total += inc
-	return total, baseErr
+	inc, newInc, err := o.baseObject.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }

--- a/object.go
+++ b/object.go
@@ -1932,8 +1932,8 @@ func computeMemUsageEstimate(memUsage, samplesVisited uint64, totalProps int) ui
 // estimateMemUsage helps calculating mem usage for large objects.
 // It will sample the object and use those samples to estimate the
 // mem usage.
-func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	var samplesVisited uint64
+func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, newEstimate uint64, err error) {
+	var samplesVisited, memUsage, newMemUsage uint64
 	totalProps := len(o.propNames)
 	sampleSize := totalProps / 10
 

--- a/object_dynamic.go
+++ b/object_dynamic.go
@@ -565,7 +565,7 @@ func (o *baseDynamicObject) getPrivateEnv(*privateEnvType, bool) *privateElement
 
 func (o *baseDynamicObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
 
 	return o.val.MemUsage(ctx)
@@ -807,7 +807,7 @@ func (a *dynamicArray) keys(all bool, accum []Value) []Value {
 
 func (a *dynamicArray) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
 	return a.val.MemUsage(ctx)
 }

--- a/object_dynamic.go
+++ b/object_dynamic.go
@@ -563,8 +563,12 @@ func (o *baseDynamicObject) getPrivateEnv(*privateEnvType, bool) *privateElement
 	panic(newTypeError("Dynamic objects cannot have private elements"))
 }
 
-func (b *baseDynamicObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return b.val.MemUsage(ctx)
+func (o *baseDynamicObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if o == nil {
+		return SizeEmpty, SizeEmpty, err
+	}
+
+	return o.val.MemUsage(ctx)
 }
 
 func (a *dynamicArray) sortLen() int {
@@ -801,6 +805,9 @@ func (a *dynamicArray) keys(all bool, accum []Value) []Value {
 	return a.stringKeys(all, accum)
 }
 
-func (a *dynamicArray) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (a *dynamicArray) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if a == nil {
+		return SizeEmpty, SizeEmpty, err
+	}
 	return a.val.MemUsage(ctx)
 }

--- a/object_dynamic_test.go
+++ b/object_dynamic_test.go
@@ -3,6 +3,8 @@ package goja
 import (
 	"sync"
 	"testing"
+
+	"github.com/dop251/goja/unistring"
 )
 
 type testDynObject struct {
@@ -416,5 +418,116 @@ func TestSharedDynamicArray(t *testing.T) {
 	err = <-ch
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestBaseDynamicObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *baseDynamicObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil base dynamic object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty base dynamic object",
+			val:         &baseDynamicObject{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given a base dynamic object with an empty Object",
+			val:         &baseDynamicObject{val: &Object{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should have a value of SizeEmpty given a base dynamic object with an empty Object",
+			val: &baseDynamicObject{
+				val: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			expected:    SizeEmpty + (4 + SizeInt),
+			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestDynamicArrayMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *dynamicArray
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil dynamic array",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty base dynamic array",
+			val:         &dynamicArray{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given a base dynamic array with an empty baseDynamicObject",
+			val:         &dynamicArray{baseDynamicObject: baseDynamicObject{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
 	}
 }

--- a/object_dynamic_test.go
+++ b/object_dynamic_test.go
@@ -423,32 +423,32 @@ func TestSharedDynamicArray(t *testing.T) {
 
 func TestBaseDynamicObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *baseDynamicObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *baseDynamicObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil base dynamic object",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil base dynamic object",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty base dynamic object",
-			val:         &baseDynamicObject{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty base dynamic object",
+			val:            &baseDynamicObject{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given a base dynamic object with an empty Object",
-			val:         &baseDynamicObject{val: &Object{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a base dynamic object with an empty Object",
+			val:            &baseDynamicObject{val: &Object{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should have a value of SizeEmptyStruct given a base dynamic object with an empty Object",
@@ -457,9 +457,9 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expected:    SizeEmptyStruct + (4 + SizeInt),
-			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedMem:    SizeEmptyStruct + (4 + SizeInt),
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 	}
 
@@ -472,11 +472,11 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -484,32 +484,32 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 
 func TestDynamicArrayMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *dynamicArray
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *dynamicArray
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil dynamic array",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil dynamic array",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty base dynamic array",
-			val:         &dynamicArray{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty base dynamic array",
+			val:            &dynamicArray{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given a base dynamic array with an empty baseDynamicObject",
-			val:         &dynamicArray{baseDynamicObject: baseDynamicObject{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a base dynamic array with an empty baseDynamicObject",
+			val:            &dynamicArray{baseDynamicObject: baseDynamicObject{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 	}
 
@@ -522,11 +522,11 @@ func TestDynamicArrayMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/object_dynamic_test.go
+++ b/object_dynamic_test.go
@@ -430,35 +430,35 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil base dynamic object",
+			name:        "should have a value of SizeEmptyStruct given a nil base dynamic object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty base dynamic object",
+			name:        "should have a value of SizeEmptyStruct given an empty base dynamic object",
 			val:         &baseDynamicObject{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given a base dynamic object with an empty Object",
+			name:        "should have a value of SizeEmptyStruct given a base dynamic object with an empty Object",
 			val:         &baseDynamicObject{val: &Object{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name: "should have a value of SizeEmpty given a base dynamic object with an empty Object",
+			name: "should have a value of SizeEmptyStruct given a base dynamic object with an empty Object",
 			val: &baseDynamicObject{
 				val: &Object{
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expected:    SizeEmpty + (4 + SizeInt),
-			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			expected:    SizeEmptyStruct + (4 + SizeInt),
+			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}
@@ -491,24 +491,24 @@ func TestDynamicArrayMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil dynamic array",
+			name:        "should have a value of SizeEmptyStruct given a nil dynamic array",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty base dynamic array",
+			name:        "should have a value of SizeEmptyStruct given an empty base dynamic array",
 			val:         &dynamicArray{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given a base dynamic array with an empty baseDynamicObject",
+			name:        "should have a value of SizeEmptyStruct given a base dynamic array with an empty baseDynamicObject",
 			val:         &dynamicArray{baseDynamicObject: baseDynamicObject{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 	}

--- a/object_lazy.go
+++ b/object_lazy.go
@@ -319,14 +319,15 @@ func (o *lazyObject) swap(i int, j int) {
 	obj.swap(i, j)
 }
 
-func (o *lazyObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	if o.val == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, nil
+func (o *lazyObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if o == nil || o.val == nil || ctx.IsObjVisited(o) {
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(o)
 
-	total := uint64(SizeEmpty)
-	inc, err := o.val.MemUsage(ctx)
-	total += inc
-	return total, err
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
+	inc, newInc, err := o.val.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }

--- a/object_lazy.go
+++ b/object_lazy.go
@@ -321,12 +321,12 @@ func (o *lazyObject) swap(i int, j int) {
 
 func (o *lazyObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || o.val == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(o)
 
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 	inc, newInc, err := o.val.MemUsage(ctx)
 
 	return memUsage + inc, newMemUsage + newInc, err

--- a/object_lazy_test.go
+++ b/object_lazy_test.go
@@ -13,24 +13,24 @@ func TestObjectLazyMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil lazy object",
+			name:        "should have a value of SizeEmptyStruct given a nil lazy object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty lazy object",
+			name:        "should have a value of SizeEmptyStruct given an empty lazy object",
 			val:         &lazyObject{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given a base dynamic array with an empty val",
+			name:        "should have a value of SizeEmptyStruct given a base dynamic array with an empty val",
 			val:         &lazyObject{val: &Object{}},
-			expected:    SizeEmpty + SizeEmpty,
-			newExpected: SizeEmpty + SizeEmpty,
+			expected:    SizeEmptyStruct + SizeEmptyStruct,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 	}

--- a/object_lazy_test.go
+++ b/object_lazy_test.go
@@ -1,0 +1,55 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestObjectLazyMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *lazyObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil lazy object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty lazy object",
+			val:         &lazyObject{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given a base dynamic array with an empty val",
+			val:         &lazyObject{val: &Object{}},
+			expected:    SizeEmpty + SizeEmpty,
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/object_lazy_test.go
+++ b/object_lazy_test.go
@@ -6,32 +6,32 @@ import (
 
 func TestObjectLazyMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *lazyObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *lazyObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil lazy object",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil lazy object",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty lazy object",
-			val:         &lazyObject{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty lazy object",
+			val:            &lazyObject{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given a base dynamic array with an empty val",
-			val:         &lazyObject{val: &Object{}},
-			expected:    SizeEmptyStruct + SizeEmptyStruct,
-			newExpected: SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a base dynamic array with an empty val",
+			val:            &lazyObject{val: &Object{}},
+			expectedMem:    SizeEmptyStruct + SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 	}
 
@@ -44,11 +44,11 @@ func TestObjectLazyMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -656,19 +656,19 @@ func TestBaseObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil object",
+			name:        "should have a value of SizeEmptyStruct given a nil object",
 			threshold:   100,
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty object",
+			name:        "should have a value of SizeEmptyStruct given an empty object",
 			threshold:   100,
 			val:         &baseObject{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -676,9 +676,9 @@ func TestBaseObjectMemUsage(t *testing.T) {
 			threshold: 100,
 			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			// overhead + len("test") + value
-			expected: SizeEmpty + 4 + SizeInt,
+			expected: SizeEmptyStruct + 4 + SizeInt,
 			// overhead + len("test") with string overhead + value
-			newExpected: SizeEmpty + (4 + SizeString) + SizeInt,
+			newExpected: SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			errExpected: nil,
 		},
 		{
@@ -686,9 +686,9 @@ func TestBaseObjectMemUsage(t *testing.T) {
 			threshold: 100,
 			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": nil}},
 			// overhead + len("test")
-			expected: SizeEmpty + 4,
+			expected: SizeEmptyStruct + 4,
 			// overhead + len("test") with string overhead
-			newExpected: SizeEmpty + (4 + SizeString),
+			newExpected: SizeEmptyStruct + (4 + SizeString),
 			errExpected: nil,
 		},
 		{
@@ -709,9 +709,9 @@ func TestBaseObjectMemUsage(t *testing.T) {
 				},
 			},
 			// overhead + len("testN") + value
-			expected: SizeEmpty + (5+SizeInt)*4,
+			expected: SizeEmptyStruct + (5+SizeInt)*4,
 			// overhead + len("testN") with string overhead + value
-			newExpected: SizeEmpty + ((5+SizeString)+SizeInt)*4,
+			newExpected: SizeEmptyStruct + ((5+SizeString)+SizeInt)*4,
 			errExpected: nil,
 		},
 		{
@@ -719,9 +719,9 @@ func TestBaseObjectMemUsage(t *testing.T) {
 			threshold: 100,
 			val:       &baseObject{prototype: &Object{}},
 			// baseObject overhead + prototype overhead
-			expected: SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct,
 			// baseObject overhead + prototype overhead
-			newExpected: SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 	}
@@ -754,44 +754,44 @@ func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil primitive value object",
+			name:        "should have a value of SizeEmptyStruct given a nil primitive value object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty primitive value object",
+			name:        "should have a value of SizeEmptyStruct given an empty primitive value object",
 			val:         &primitiveValueObject{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "should account for overhead given a primitive value object with empty object",
 			val:  &primitiveValueObject{baseObject: baseObject{}},
 			// baseObject overhead + len("test") + value
-			expected: SizeEmpty,
+			expected: SizeEmptyStruct,
 			// baseObject overhead + len("test") with string overhead + value
-			newExpected: SizeEmpty,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "should account for overehead and each key value pair given a primitive value object with non-empty object",
 			val:  &primitiveValueObject{baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}}},
 			// baseObject overhead + len("test") + value
-			expected: SizeEmpty + 4 + SizeInt,
+			expected: SizeEmptyStruct + 4 + SizeInt,
 			// baseObject overhead + len("test") with string overhead + value
-			newExpected: SizeEmpty + (4 + SizeString) + SizeInt,
+			newExpected: SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			errExpected: nil,
 		},
 		{
 			name: "should account for pValue given a primitive value object with non-empty pValue",
 			val:  &primitiveValueObject{pValue: valueInt(99)},
 			// baseObject overhead + value
-			expected: SizeEmpty + SizeInt,
+			expected: SizeEmptyStruct + SizeInt,
 			// baseObject overhead + value
-			newExpected: SizeEmpty + SizeInt,
+			newExpected: SizeEmptyStruct + SizeInt,
 			errExpected: nil,
 		},
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/dop251/goja/unistring"
 )
 
 func TestDefineProperty(t *testing.T) {
@@ -641,5 +643,174 @@ func BenchmarkAddString(b *testing.B) {
 		if !z.StrictEquals(tst) {
 			b.Fatalf("Unexpected result %v", x)
 		}
+	}
+}
+
+func TestBaseObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *baseObject
+		threshold   int
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil object",
+			threshold:   100,
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty object",
+			threshold:   100,
+			val:         &baseObject{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:      "should account for each key value pair given a non-empty object",
+			threshold: 100,
+			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+			// overhead + len("test") + value
+			expected: SizeEmpty + 4 + SizeInt,
+			// overhead + len("test") with string overhead + value
+			newExpected: SizeEmpty + (4 + SizeString) + SizeInt,
+			errExpected: nil,
+		},
+		{
+			name:      "should account for each key value pair given a non-empty object with a nil value",
+			threshold: 100,
+			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": nil}},
+			// overhead + len("test")
+			expected: SizeEmpty + 4,
+			// overhead + len("test") with string overhead
+			newExpected: SizeEmpty + (4 + SizeString),
+			errExpected: nil,
+		},
+		{
+			name:      "should account for sampled key value pair given a non-empty object over threshold",
+			threshold: 20,
+			val: &baseObject{
+				propNames: []unistring.String{
+					"test0",
+					"test1",
+					"test2",
+					"test3",
+				},
+				values: map[unistring.String]Value{
+					"test0": valueInt(99),
+					"test1": valueInt(99),
+					"test2": valueInt(99),
+					"test3": valueInt(99),
+				},
+			},
+			// overhead + len("testN") + value
+			expected: SizeEmpty + (5+SizeInt)*4,
+			// overhead + len("testN") with string overhead + value
+			newExpected: SizeEmpty + ((5+SizeString)+SizeInt)*4,
+			errExpected: nil,
+		},
+		{
+			name:      "should account for prototype's given an object with a valid prototype",
+			threshold: 100,
+			val:       &baseObject{prototype: &Object{}},
+			// baseObject overhead + prototype overhead
+			expected: SizeEmpty + SizeEmpty,
+			// baseObject overhead + prototype overhead
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, tc.threshold, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestPrimitiveValueObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *primitiveValueObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil primitive value object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty primitive value object",
+			val:         &primitiveValueObject{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for overhead given a primitive value object with empty object",
+			val:  &primitiveValueObject{baseObject: baseObject{}},
+			// baseObject overhead + len("test") + value
+			expected: SizeEmpty,
+			// baseObject overhead + len("test") with string overhead + value
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for overehead and each key value pair given a primitive value object with non-empty object",
+			val:  &primitiveValueObject{baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}}},
+			// baseObject overhead + len("test") + value
+			expected: SizeEmpty + 4 + SizeInt,
+			// baseObject overhead + len("test") with string overhead + value
+			newExpected: SizeEmpty + (4 + SizeString) + SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for pValue given a primitive value object with non-empty pValue",
+			val:  &primitiveValueObject{pValue: valueInt(99)},
+			// baseObject overhead + value
+			expected: SizeEmpty + SizeInt,
+			// baseObject overhead + value
+			newExpected: SizeEmpty + SizeInt,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
 	}
 }

--- a/object_test.go
+++ b/object_test.go
@@ -648,48 +648,48 @@ func BenchmarkAddString(b *testing.B) {
 
 func TestBaseObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *baseObject
-		threshold   int
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *baseObject
+		threshold      int
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil object",
-			threshold:   100,
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil object",
+			threshold:      100,
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty object",
-			threshold:   100,
-			val:         &baseObject{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty object",
+			threshold:      100,
+			val:            &baseObject{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name:      "should account for each key value pair given a non-empty object",
 			threshold: 100,
 			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			// overhead + len("test") + value
-			expected: SizeEmptyStruct + 4 + SizeInt,
+			expectedMem: SizeEmptyStruct + 4 + SizeInt,
 			// overhead + len("test") with string overhead + value
-			newExpected: SizeEmptyStruct + (4 + SizeString) + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name:      "should account for each key value pair given a non-empty object with a nil value",
 			threshold: 100,
 			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": nil}},
 			// overhead + len("test")
-			expected: SizeEmptyStruct + 4,
+			expectedMem: SizeEmptyStruct + 4,
 			// overhead + len("test") with string overhead
-			newExpected: SizeEmptyStruct + (4 + SizeString),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString),
+			errExpected:    nil,
 		},
 		{
 			name:      "should account for sampled key value pair given a non-empty object over threshold",
@@ -709,20 +709,20 @@ func TestBaseObjectMemUsage(t *testing.T) {
 				},
 			},
 			// overhead + len("testN") + value
-			expected: SizeEmptyStruct + (5+SizeInt)*4,
+			expectedMem: SizeEmptyStruct + (5+SizeInt)*4,
 			// overhead + len("testN") with string overhead + value
-			newExpected: SizeEmptyStruct + ((5+SizeString)+SizeInt)*4,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*4,
+			errExpected:    nil,
 		},
 		{
 			name:      "should account for prototype's given an object with a valid prototype",
 			threshold: 100,
 			val:       &baseObject{prototype: &Object{}},
 			// baseObject overhead + prototype overhead
-			expected: SizeEmptyStruct + SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// baseObject overhead + prototype overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 	}
 
@@ -735,11 +735,11 @@ func TestBaseObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -747,52 +747,52 @@ func TestBaseObjectMemUsage(t *testing.T) {
 
 func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *primitiveValueObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *primitiveValueObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil primitive value object",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil primitive value object",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty primitive value object",
-			val:         &primitiveValueObject{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty primitive value object",
+			val:            &primitiveValueObject{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for overhead given a primitive value object with empty object",
 			val:  &primitiveValueObject{baseObject: baseObject{}},
 			// baseObject overhead + len("test") + value
-			expected: SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct,
 			// baseObject overhead + len("test") with string overhead + value
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for overehead and each key value pair given a primitive value object with non-empty object",
 			val:  &primitiveValueObject{baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}}},
 			// baseObject overhead + len("test") + value
-			expected: SizeEmptyStruct + 4 + SizeInt,
+			expectedMem: SizeEmptyStruct + 4 + SizeInt,
 			// baseObject overhead + len("test") with string overhead + value
-			newExpected: SizeEmptyStruct + (4 + SizeString) + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for pValue given a primitive value object with non-empty pValue",
 			val:  &primitiveValueObject{pValue: valueInt(99)},
 			// baseObject overhead + value
-			expected: SizeEmptyStruct + SizeInt,
+			expectedMem: SizeEmptyStruct + SizeInt,
 			// baseObject overhead + value
-			newExpected: SizeEmptyStruct + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
 		},
 	}
 
@@ -805,11 +805,11 @@ func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -1056,7 +1056,7 @@ func (p *proxyObject) revoke() {
 
 func (p *proxyObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if p == nil || ctx.IsObjVisited(p) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(p)
 
@@ -1064,8 +1064,8 @@ func (p *proxyObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsa
 		return 0, 0, err
 	}
 
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 	inc, newInc, err := p.baseObject.MemUsage(ctx)
 	memUsage += inc
 	newMemUsage += newInc
@@ -1098,7 +1098,7 @@ func (p *proxyObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsa
 
 func (h *jsProxyHandler) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if h == nil || h.handler == nil || ctx.IsObjVisited(h.handler.self) {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
 	return h.handler.MemUsage(ctx)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -1054,47 +1054,51 @@ func (p *proxyObject) revoke() {
 	p.target = nil
 }
 
-func (p *proxyObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (p *proxyObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if p == nil || ctx.IsObjVisited(p) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(p)
 
 	if err := ctx.Descend(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	total := SizeEmpty
-	inc, baseObjetErr := p.baseObject.MemUsage(ctx)
-	total += inc
-	if baseObjetErr != nil {
-		return total, baseObjetErr
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
+	inc, newInc, err := p.baseObject.MemUsage(ctx)
+	memUsage += inc
+	newMemUsage += newInc
+	if err != nil {
+		return memUsage, newMemUsage, err
 	}
 
 	if p.target != nil {
-		inc, err := p.target.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := p.target.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	if p.handler != nil {
-		inc, err := p.handler.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := p.handler.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	ctx.Ascend()
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
-func (h *jsProxyHandler) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (h *jsProxyHandler) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if h == nil || h.handler == nil || ctx.IsObjVisited(h.handler.self) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, err
 	}
 	return h.handler.MemUsage(ctx)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -145,7 +145,7 @@ type proxyHandler interface {
 
 	toObject(*Runtime) *Object
 
-	MemUsage(ctx *MemUsageContext) (uint64, error)
+	MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error)
 }
 
 type jsProxyHandler struct {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -8,36 +8,36 @@ import (
 
 func TestProxyMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *proxyObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *proxyObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil proxy object",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil proxy object",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for base object overhead given an empty proxy object",
 			val:  &proxyObject{},
 			// proxy overhead + baseObject overhead
-			expected: SizeEmptyStruct + SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// proxy overhead + baseObject overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for baseObject and target overhead given a proxy object with empty target",
 			val:  &proxyObject{target: &Object{}},
 			// proxy overhead + baseObject overhead + target overhead
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			// proxy overhead + baseObject overhead + target overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for baseObjet overhead and target given a proxy object with a non-empty target",
@@ -47,19 +47,19 @@ func TestProxyMemUsage(t *testing.T) {
 				},
 			},
 			// proxy overhead + baseObject overhead + target overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 		{
 			name: "should account for baseObject overhead given a base dynamic array with an empty handler",
 			val:  &proxyObject{handler: &jsProxyHandler{handler: &Object{}}},
 			// proxy overhead + baseObject overhead + target overhead
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			// proxy overhead + baseObject overhead + target overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for baseObject overhead and handler given a base dynamic array with a non-empty handler",
@@ -71,10 +71,10 @@ func TestProxyMemUsage(t *testing.T) {
 				},
 			},
 			// proxy overhead + baseObject overhead + target overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 	}
 
@@ -87,11 +87,11 @@ func TestProxyMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -99,25 +99,25 @@ func TestProxyMemUsage(t *testing.T) {
 
 func TestJSProxyHandlerMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *jsProxyHandler
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *jsProxyHandler
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil proxy handler",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil proxy handler",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty proxy handler",
-			val:         &jsProxyHandler{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty proxy handler",
+			val:            &jsProxyHandler{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should have a value of SizeEmptyStruct given an empty proxy handler",
@@ -127,10 +127,10 @@ func TestJSProxyHandlerMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject overhead + key/value pair
-			expected: SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 	}
 
@@ -143,11 +143,11 @@ func TestJSProxyHandlerMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -15,28 +15,28 @@ func TestProxyMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil proxy object",
+			name:        "should have a value of SizeEmptyStruct given a nil proxy object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "should account for base object overhead given an empty proxy object",
 			val:  &proxyObject{},
 			// proxy overhead + baseObject overhead
-			expected: SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct,
 			// proxy overhead + baseObject overhead
-			newExpected: SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "should account for baseObject and target overhead given a proxy object with empty target",
 			val:  &proxyObject{target: &Object{}},
 			// proxy overhead + baseObject overhead + target overhead
-			expected: SizeEmpty + SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			// proxy overhead + baseObject overhead + target overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -47,18 +47,18 @@ func TestProxyMemUsage(t *testing.T) {
 				},
 			},
 			// proxy overhead + baseObject overhead + target overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 		{
 			name: "should account for baseObject overhead given a base dynamic array with an empty handler",
 			val:  &proxyObject{handler: &jsProxyHandler{handler: &Object{}}},
 			// proxy overhead + baseObject overhead + target overhead
-			expected: SizeEmpty + SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			// proxy overhead + baseObject overhead + target overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -71,9 +71,9 @@ func TestProxyMemUsage(t *testing.T) {
 				},
 			},
 			// proxy overhead + baseObject overhead + target overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}
@@ -106,30 +106,30 @@ func TestJSProxyHandlerMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil proxy handler",
+			name:        "should have a value of SizeEmptyStruct given a nil proxy handler",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty proxy handler",
+			name:        "should have a value of SizeEmptyStruct given an empty proxy handler",
 			val:         &jsProxyHandler{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name: "should have a value of SizeEmpty given an empty proxy handler",
+			name: "should have a value of SizeEmptyStruct given an empty proxy handler",
 			val: &jsProxyHandler{
 				handler: &Object{
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
 			// baseObject overhead + key/value pair
-			expected: SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,154 @@
+package goja
+
+import (
+	"testing"
+
+	"github.com/dop251/goja/unistring"
+)
+
+func TestProxyMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *proxyObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil proxy object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for base object overhead given an empty proxy object",
+			val:  &proxyObject{},
+			// proxy overhead + baseObject overhead
+			expected: SizeEmpty + SizeEmpty,
+			// proxy overhead + baseObject overhead
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject and target overhead given a proxy object with empty target",
+			val:  &proxyObject{target: &Object{}},
+			// proxy overhead + baseObject overhead + target overhead
+			expected: SizeEmpty + SizeEmpty + SizeEmpty,
+			// proxy overhead + baseObject overhead + target overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObjet overhead and target given a proxy object with a non-empty target",
+			val: &proxyObject{
+				target: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// proxy overhead + baseObject overhead + target overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead given a base dynamic array with an empty handler",
+			val:  &proxyObject{handler: &jsProxyHandler{handler: &Object{}}},
+			// proxy overhead + baseObject overhead + target overhead
+			expected: SizeEmpty + SizeEmpty + SizeEmpty,
+			// proxy overhead + baseObject overhead + target overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead and handler given a base dynamic array with a non-empty handler",
+			val: &proxyObject{
+				handler: &jsProxyHandler{
+					handler: &Object{
+						self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+					},
+				},
+			},
+			// proxy overhead + baseObject overhead + target overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestJSProxyHandlerMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *jsProxyHandler
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil proxy handler",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty proxy handler",
+			val:         &jsProxyHandler{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should have a value of SizeEmpty given an empty proxy handler",
+			val: &jsProxyHandler{
+				handler: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// baseObject overhead + key/value pair
+			expected: SizeEmpty + (4 + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -512,42 +512,52 @@ func (r *Runtime) typeErrorResult(throw bool, args ...interface{}) {
 	}
 }
 
-func (r *Runtime) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	total := uint64(0)
+func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if r == nil {
+		return SizeEmpty, SizeEmpty, err
+	}
 
 	if r.globalObject != nil {
-		inc, err := r.globalObject.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := r.globalObject.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	for idx := range r.vm.callStack {
-		inc, err := r.vm.callStack[idx].MemUsage(ctx)
-		total += inc
-		if err != nil {
-			return total, err
+	if r.vm != nil {
+		if r.vm.callStack != nil {
+			for idx := range r.vm.callStack {
+				inc, newInc, err := r.vm.callStack[idx].MemUsage(ctx)
+				memUsage += inc
+				newMemUsage += newInc
+				if err != nil {
+					return memUsage, newMemUsage, err
+				}
+			}
+		}
+
+		if r.vm.stash != nil {
+			inc, newInc, err := r.vm.stash.MemUsage(ctx)
+			memUsage += inc
+			newMemUsage += newInc
+			if err != nil {
+				return memUsage, newMemUsage, err
+			}
+		}
+
+		if r.vm.stack != nil {
+			inc, newInc, err := r.vm.stack.MemUsage(ctx)
+			memUsage += inc
+			newMemUsage += newInc
+			if err != nil {
+				return memUsage, newMemUsage, err
+			}
 		}
 	}
 
-	if r.vm.stash != nil {
-		inc, err := r.vm.stash.MemUsage(ctx)
-		total += inc
-		if err != nil {
-			return total, err
-		}
-	}
-
-	if r.vm.stack != nil {
-		inc, err := r.vm.stack.MemUsage(ctx)
-		total += inc
-		if err != nil {
-			return total, err
-		}
-	}
-
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
 func (r *Runtime) newError(typ *Object, format string, args ...interface{}) Value {

--- a/runtime.go
+++ b/runtime.go
@@ -526,34 +526,36 @@ func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage u
 		}
 	}
 
-	if r.vm != nil {
-		if r.vm.callStack != nil {
-			for idx := range r.vm.callStack {
-				inc, newInc, err := r.vm.callStack[idx].MemUsage(ctx)
-				memUsage += inc
-				newMemUsage += newInc
-				if err != nil {
-					return memUsage, newMemUsage, err
-				}
-			}
-		}
+	if r.vm == nil {
+		return memUsage, newMemUsage, nil
+	}
 
-		if r.vm.stash != nil {
-			inc, newInc, err := r.vm.stash.MemUsage(ctx)
+	if r.vm.callStack != nil {
+		for idx := range r.vm.callStack {
+			inc, newInc, err := r.vm.callStack[idx].MemUsage(ctx)
 			memUsage += inc
 			newMemUsage += newInc
 			if err != nil {
 				return memUsage, newMemUsage, err
 			}
 		}
+	}
 
-		if r.vm.stack != nil {
-			inc, newInc, err := r.vm.stack.MemUsage(ctx)
-			memUsage += inc
-			newMemUsage += newInc
-			if err != nil {
-				return memUsage, newMemUsage, err
-			}
+	if r.vm.stash != nil {
+		inc, newInc, err := r.vm.stash.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
+		if err != nil {
+			return memUsage, newMemUsage, err
+		}
+	}
+
+	if r.vm.stack != nil {
+		inc, newInc, err := r.vm.stack.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
+		if err != nil {
+			return memUsage, newMemUsage, err
 		}
 	}
 

--- a/runtime.go
+++ b/runtime.go
@@ -514,7 +514,7 @@ func (r *Runtime) typeErrorResult(throw bool, args ...interface{}) {
 
 func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if r == nil {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
 
 	if r.globalObject != nil {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2988,10 +2988,10 @@ func TestRuntimeMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil runtime",
+			name:        "should have a value of SizeEmptyStruct given a nil runtime",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -3002,9 +3002,9 @@ func TestRuntimeMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject overhead + key/value pair
-			expected: SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 		{
@@ -3013,9 +3013,9 @@ func TestRuntimeMemUsage(t *testing.T) {
 				vm: &vm{callStack: []vmContext{{newTarget: valueInt(99)}}},
 			},
 			// vmContext overhead + value
-			expected: SizeEmpty + SizeInt,
+			expected: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + value
-			newExpected: SizeEmpty + SizeInt,
+			newExpected: SizeEmptyStruct + SizeInt,
 			errExpected: nil,
 		},
 		{

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2981,18 +2981,18 @@ func TestErrorCaptureStackTrace(t *testing.T) {
 
 func TestRuntimeMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *Runtime
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *Runtime
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil runtime",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil runtime",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for globalObject given a runtime with non-empty globalObject",
@@ -3002,10 +3002,10 @@ func TestRuntimeMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject overhead + key/value pair
-			expected: SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 		{
 			name: "should account for vm callStack given a runtime with a vm and a non-empty callStack",
@@ -3013,10 +3013,10 @@ func TestRuntimeMemUsage(t *testing.T) {
 				vm: &vm{callStack: []vmContext{{newTarget: valueInt(99)}}},
 			},
 			// vmContext overhead + value
-			expected: SizeEmptyStruct + SizeInt,
+			expectedMem: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + value
-			newExpected: SizeEmptyStruct + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for vm stash given a runtime with a vm and a non-empty stash",
@@ -3024,10 +3024,10 @@ func TestRuntimeMemUsage(t *testing.T) {
 				vm: &vm{stash: &stash{values: []Value{valueInt(99)}}},
 			},
 			// stash value
-			expected: SizeInt,
+			expectedMem: SizeInt,
 			// stash value
-			newExpected: SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for vm stack given a runtime with a vm and a non-empty stack",
@@ -3035,10 +3035,10 @@ func TestRuntimeMemUsage(t *testing.T) {
 				vm: &vm{stack: []Value{valueInt(99)}},
 			},
 			// stack value
-			expected: SizeInt,
+			expectedMem: SizeInt,
 			// stack value
-			newExpected: SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 	}
 
@@ -3051,11 +3051,11 @@ func TestRuntimeMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja/parser"
+	"github.com/dop251/goja/unistring"
 )
 
 func TestGlobalObjectProto(t *testing.T) {
@@ -2976,4 +2977,86 @@ func TestErrorCaptureStackTrace(t *testing.T) {
 		new Error("oh no!").captureStackTrace();
 	`
 	testScript(SCRIPT, newStringValue(""), t)
+}
+
+func TestRuntimeMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *Runtime
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil runtime",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for globalObject given a runtime with non-empty globalObject",
+			val: &Runtime{
+				globalObject: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// baseObject overhead + key/value pair
+			expected: SizeEmpty + (4 + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+		{
+			name: "should account for vm callStack given a runtime with a vm and a non-empty callStack",
+			val: &Runtime{
+				vm: &vm{callStack: []vmContext{{newTarget: valueInt(99)}}},
+			},
+			// vmContext overhead + value
+			expected: SizeEmpty + SizeInt,
+			// vmContext overhead + value
+			newExpected: SizeEmpty + SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for vm stash given a runtime with a vm and a non-empty stash",
+			val: &Runtime{
+				vm: &vm{stash: &stash{values: []Value{valueInt(99)}}},
+			},
+			// stash value
+			expected: SizeInt,
+			// stash value
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for vm stack given a runtime with a vm and a non-empty stack",
+			val: &Runtime{
+				vm: &vm{stack: []Value{valueInt(99)}},
+			},
+			// stack value
+			expected: SizeInt,
+			// stack value
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
 }

--- a/string.go
+++ b/string.go
@@ -330,7 +330,7 @@ func unknownStringTypeErr(v Value) interface{} {
 
 func (s *stringObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if s == nil || ctx.IsObjVisited(s) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(s)
 

--- a/string.go
+++ b/string.go
@@ -328,14 +328,15 @@ func unknownStringTypeErr(v Value) interface{} {
 	return newTypeError("Internal bug: unknown string type: %T", v)
 }
 
-func (s *stringObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (s *stringObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if s == nil || ctx.IsObjVisited(s) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(s)
 
-	total := uint64(s.length)
-	inc, err := s.baseObject.MemUsage(ctx)
-	total += inc
-	return total, err
+	memUsage = uint64(s.length)
+	newMemUsage = uint64(s.length) + SizeString
+	inc, newInc, err := s.baseObject.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -332,8 +332,8 @@ func (s asciiString) ExportType() reflect.Type {
 	return reflectTypeString
 }
 
-func (s asciiString) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(s.length()) + SizeString, nil
+func (s asciiString) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return uint64(s.length()), uint64(s.length()) + SizeString, err
 }
 
 func (s asciiString) ToInt() int {

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -333,7 +333,7 @@ func (s asciiString) ExportType() reflect.Type {
 }
 
 func (s asciiString) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(s.length()), nil
+	return uint64(s.length()) + SizeString, nil
 }
 
 func (s asciiString) ToInt() int {

--- a/string_ascii_test.go
+++ b/string_ascii_test.go
@@ -1,0 +1,41 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestStringAsciiMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         asciiString
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value given the length of the string",
+			val:         asciiString("yo"),
+			expected:    2,
+			newExpected: 2 + SizeString, // length with string overhead
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/string_ascii_test.go
+++ b/string_ascii_test.go
@@ -6,18 +6,25 @@ import (
 
 func TestStringAsciiMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         asciiString
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            asciiString
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value given the length of the string",
-			val:         asciiString("yo"),
-			expected:    2,
-			newExpected: 2 + SizeString, // length with string overhead
-			errExpected: nil,
+			name:           "should have a value of 0/SizeString given an empty string",
+			val:            asciiString(""),
+			expectedMem:    0,
+			expectedNewMem: SizeString, // string overhead
+			errExpected:    nil,
+		},
+		{
+			name:           "should have a value given the length of the string",
+			val:            asciiString("yo"),
+			expectedMem:    2,
+			expectedNewMem: 2 + SizeString, // length with string overhead
+			errExpected:    nil,
 		},
 	}
 
@@ -30,11 +37,11 @@ func TestStringAsciiMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/string_imported.go
+++ b/string_imported.go
@@ -350,6 +350,6 @@ func (i *importedString) toTrimmedUTF8() string {
 	return strings.Trim(i.s, parser.WhitespaceChars)
 }
 
-func (i *importedString) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(len(i.String())) + SizeString, nil
+func (i *importedString) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return uint64(len(i.String())), uint64(len(i.String())) + SizeString, err
 }

--- a/string_imported.go
+++ b/string_imported.go
@@ -351,5 +351,5 @@ func (i *importedString) toTrimmedUTF8() string {
 }
 
 func (i *importedString) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(len(i.String())), nil
+	return uint64(len(i.String())) + SizeString, nil
 }

--- a/string_imported_test.go
+++ b/string_imported_test.go
@@ -1,0 +1,41 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestStringImportedMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *importedString
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value given the length of the string",
+			val:         &importedString{s: "yo"},
+			expected:    2,
+			newExpected: 2 + SizeString, // length with string overhead
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/string_imported_test.go
+++ b/string_imported_test.go
@@ -6,18 +6,25 @@ import (
 
 func TestStringImportedMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *importedString
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *importedString
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value given the length of the string",
-			val:         &importedString{s: "yo"},
-			expected:    2,
-			newExpected: 2 + SizeString, // length with string overhead
-			errExpected: nil,
+			name:           "should have a value of 0/SizeString given an empty string",
+			val:            &importedString{s: ""},
+			expectedMem:    0,
+			expectedNewMem: SizeString, // string overhead
+			errExpected:    nil,
+		},
+		{
+			name:           "should have a value given the length of the string",
+			val:            &importedString{s: "yo"},
+			expectedMem:    2,
+			expectedNewMem: 2 + SizeString, // length with string overhead
+			errExpected:    nil,
 		},
 	}
 
@@ -30,11 +37,11 @@ func TestStringImportedMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/string_test.go
+++ b/string_test.go
@@ -9,7 +9,7 @@ import (
 func TestStringOOBProperties(t *testing.T) {
 	const SCRIPT = `
 	var string = new String("str");
-	
+
 	string[4] = 1;
 	string[4];
 	`
@@ -162,5 +162,44 @@ func BenchmarkASCIIConcat(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Unexpected errors %s", err)
 		}
+	}
+}
+
+func TestStringObjectMemUsage(t *testing.T) {
+	vm := New()
+
+	for _, tc := range []struct {
+		name           string
+		val            *stringObject
+		expectedMem    uint64
+		expectedNewMem uint64
+	}{
+		{
+			"should return SizeEmpty given a nil stringObject",
+			nil,
+			SizeEmpty,
+			SizeEmpty,
+		},
+		{
+			"should account for base object and data given a non-empty stringObject",
+			&stringObject{value: newStringValue("yo"), length: 2},
+			// baseObject + len("yo")
+			SizeEmpty + 2,
+			// baseObject + len("yo") and string overhead
+			SizeEmpty + (2 + SizeString),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem, newMem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, nil))
+			if err != nil {
+				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
+			}
+			if mem != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", mem, tc.expectedMem)
+			}
+			if newMem != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newMem, tc.expectedNewMem)
+			}
+		})
 	}
 }

--- a/string_test.go
+++ b/string_test.go
@@ -175,18 +175,18 @@ func TestStringObjectMemUsage(t *testing.T) {
 		expectedNewMem uint64
 	}{
 		{
-			"should return SizeEmpty given a nil stringObject",
+			"should return SizeEmptyStruct given a nil stringObject",
 			nil,
-			SizeEmpty,
-			SizeEmpty,
+			SizeEmptyStruct,
+			SizeEmptyStruct,
 		},
 		{
 			"should account for base object and data given a non-empty stringObject",
 			&stringObject{value: newStringValue("yo"), length: 2},
 			// baseObject + len("yo")
-			SizeEmpty + 2,
+			SizeEmptyStruct + 2,
 			// baseObject + len("yo") and string overhead
-			SizeEmpty + (2 + SizeString),
+			SizeEmptyStruct + (2 + SizeString),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/string_unicode.go
+++ b/string_unicode.go
@@ -559,8 +559,8 @@ func (s unicodeString) string() unistring.String {
 	return unistring.FromUtf16(s)
 }
 
-func (s unicodeString) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(len(s.String())) + SizeString, nil
+func (s unicodeString) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return uint64(len(s.String())), uint64(len(s.String())) + SizeString, err
 }
 func (s unicodeString) ToInt() int {
 	return 0

--- a/string_unicode.go
+++ b/string_unicode.go
@@ -560,7 +560,7 @@ func (s unicodeString) string() unistring.String {
 }
 
 func (s unicodeString) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(len(s.String())), nil
+	return uint64(len(s.String())) + SizeString, nil
 }
 func (s unicodeString) ToInt() int {
 	return 0

--- a/string_unicode_test.go
+++ b/string_unicode_test.go
@@ -6,18 +6,25 @@ import (
 
 func TestStringUnicodeMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         unicodeString
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            unicodeString
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value given the length of the string",
-			val:         unicodeString{' ', 'y', 'o'},
-			expected:    2,
-			newExpected: 2 + SizeString, // length with string overhead
-			errExpected: nil,
+			name:           "should have a value of 0/SizeString given an empty string",
+			val:            unicodeString{' '},
+			expectedMem:    0,
+			expectedNewMem: SizeString, // string overhead
+			errExpected:    nil,
+		},
+		{
+			name:           "should have a value given the length of the string",
+			val:            unicodeString{' ', 'y', 'o'},
+			expectedMem:    2,
+			expectedNewMem: 2 + SizeString, // length with string overhead
+			errExpected:    nil,
 		},
 	}
 
@@ -30,11 +37,11 @@ func TestStringUnicodeMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/string_unicode_test.go
+++ b/string_unicode_test.go
@@ -1,0 +1,41 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestStringUnicodeMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         unicodeString
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value given the length of the string",
+			val:         unicodeString{' ', 'y', 'o'},
+			expected:    2,
+			newExpected: 2 + SizeString, // length with string overhead
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/typedarrays.go
+++ b/typedarrays.go
@@ -108,7 +108,7 @@ func (a ArrayBuffer) Detached() bool {
 	return a.buf.detached
 }
 
-func (a ArrayBuffer) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (a ArrayBuffer) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	return a.buf.MemUsage(ctx)
 }
 
@@ -705,32 +705,35 @@ func (a *typedArrayObject) iterateStringKeys() iterNextFunc {
 	}).next
 }
 
-func (a *typedArrayObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (a *typedArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(a)
 
-	total := SizeEmpty
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
 	if a.viewedArrayBuf != nil {
-		inc, err := a.viewedArrayBuf.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := a.viewedArrayBuf.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	if a.defaultCtor != nil {
-		inc, err := a.defaultCtor.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := a.defaultCtor.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	inc, err := a.baseObject.MemUsage(ctx)
-	total += inc
-	return total, err
+	inc, newInc, err := a.baseObject.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }
 
 func (r *Runtime) _newTypedArrayObject(buf *arrayBufferObject, offset, length, elemSize int, defCtor *Object, arr typedArray, proto *Object) *typedArrayObject {
@@ -810,24 +813,27 @@ func (o *dataViewObject) getIdxAndByteOrder(getIdx int, littleEndianVal Value, s
 	return getIdx, bo
 }
 
-func (o *dataViewObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (o *dataViewObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(o)
 
-	total := SizeEmpty
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
 	if o.viewedArrayBuf != nil {
-		inc, err := o.viewedArrayBuf.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := o.viewedArrayBuf.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	inc, err := o.baseObject.MemUsage(ctx)
-	total += inc
-	return total, err
+	inc, newInc, err := o.baseObject.MemUsage(ctx)
+	memUsage += inc
+	newMemUsage += newInc
+	return memUsage, newMemUsage, err
 }
 
 func (o *arrayBufferObject) ensureNotDetached(throw bool) bool {
@@ -968,16 +974,17 @@ func (o *arrayBufferObject) export(*objectExportCtx) interface{} {
 	}
 }
 
-func (o *arrayBufferObject) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (o *arrayBufferObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 	ctx.VisitObj(o)
 
-	total := uint64(len(o.data))
-	inc, err := o.baseObject.MemUsage(ctx)
-	total += inc
-	return total, err
+	memUsage = uint64(len(o.data))
+	newMemUsage = uint64(len(o.data))
+	inc, newInc, err := o.baseObject.MemUsage(ctx)
+
+	return memUsage + inc, newMemUsage + newInc, err
 }
 
 func (r *Runtime) _newArrayBuffer(proto *Object, o *Object) *arrayBufferObject {

--- a/typedarrays.go
+++ b/typedarrays.go
@@ -707,12 +707,12 @@ func (a *typedArrayObject) iterateStringKeys() iterNextFunc {
 
 func (a *typedArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(a)
 
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 	if a.viewedArrayBuf != nil {
 		inc, newInc, err := a.viewedArrayBuf.MemUsage(ctx)
 		memUsage += inc
@@ -815,12 +815,12 @@ func (o *dataViewObject) getIdxAndByteOrder(getIdx int, littleEndianVal Value, s
 
 func (o *dataViewObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(o)
 
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 	if o.viewedArrayBuf != nil {
 		inc, newInc, err := o.viewedArrayBuf.MemUsage(ctx)
 		memUsage += inc
@@ -976,7 +976,7 @@ func (o *arrayBufferObject) export(*objectExportCtx) interface{} {
 
 func (o *arrayBufferObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || ctx.IsObjVisited(o) {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 	ctx.VisitObj(o)
 

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -1,6 +1,10 @@
 package goja
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/dop251/goja/unistring"
+)
 
 func TestUint16ArrayObject(t *testing.T) {
 	vm := New()
@@ -339,4 +343,251 @@ func TestTypedArrayGetInvalidIndex(t *testing.T) {
 	assert.sameValue(a["1"], undefined);
 	`
 	testScriptWithTestLib(SCRIPT, _undefined, t)
+}
+
+func TestArrayBufferObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *arrayBufferObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil array buffer object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty array buffer object",
+			val:         &arrayBufferObject{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead given an array buffer object with empty baseObject",
+			val: &arrayBufferObject{
+				baseObject: baseObject{},
+			},
+			// baseObject overhead
+			expected: SizeEmpty,
+			// baseObject overhead
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead and values given an array buffer object with non-empty baseObject",
+			val: &arrayBufferObject{
+				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+			},
+			// baseObject overhead + key/value pair
+			expected: SizeEmpty + (4 + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestTypedArrayObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *typedArrayObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil typed array object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should have a value of SizeEmpty given an empty typed array object",
+			val:  &typedArrayObject{},
+			// typedArrayObject overhead + nil baseObject overhead
+			expected: SizeEmpty + SizeEmpty,
+			// typedArrayObject overhead + nil baseObject overhead
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead given a typed array object with empty baseObject",
+			val: &typedArrayObject{
+				baseObject: baseObject{},
+			},
+			// typedArrayObject overhead + baseObject overhead
+			expected: SizeEmpty + SizeEmpty,
+			// typedArrayObject overhead + baseObject overhead
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead and values given a typed array object with non-empty baseObject",
+			val: &typedArrayObject{
+				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+			},
+			// typedArrayObject overhead + baseObject overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+		{
+			name: "should account for arrayBufferObject overhead and values given a typed array object with non-empty viewedArrayBuf",
+			val: &typedArrayObject{
+				viewedArrayBuf: &arrayBufferObject{
+					baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+		{
+			name: "should account for defaultCtor overhead given a typed array object with empty defaultCtor",
+			val:  &typedArrayObject{defaultCtor: &Object{}},
+			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead
+			expected: SizeEmpty + SizeEmpty + SizeEmpty,
+			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for defaultCtor overhead and values given a typed array object with non-empty defaultCtor",
+			val: &typedArrayObject{
+				defaultCtor: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestDataViewObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *dataViewObject
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil data view object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should have a value of SizeEmpty given an empty data view object",
+			val:  &dataViewObject{},
+			// typedArrayObject overhead + nil baseObject overhead
+			expected: SizeEmpty + SizeEmpty,
+			// typedArrayObject overhead + nil baseObject overhead
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead given a data view object with empty baseObject",
+			val: &dataViewObject{
+				baseObject: baseObject{},
+			},
+			// typedArrayObject overhead + baseObject overhead
+			expected: SizeEmpty + SizeEmpty,
+			// typedArrayObject overhead + baseObject overhead
+			newExpected: SizeEmpty + SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for baseObject overhead and values given a data view object with non-empty baseObject",
+			val: &dataViewObject{
+				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+			},
+			// typedArrayObject overhead + baseObject overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+		{
+			name: "should account for arrayBufferObject overhead and values given a data view object with non-empty viewedArrayBuf",
+			val: &dataViewObject{
+				viewedArrayBuf: &arrayBufferObject{
+					baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
+			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
+			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
 }

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -354,17 +354,17 @@ func TestArrayBufferObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil array buffer object",
+			name:        "should have a value of SizeEmptyStruct given a nil array buffer object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty array buffer object",
+			name:        "should have a value of SizeEmptyStruct given an empty array buffer object",
 			val:         &arrayBufferObject{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -373,9 +373,9 @@ func TestArrayBufferObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{},
 			},
 			// baseObject overhead
-			expected: SizeEmpty,
+			expected: SizeEmptyStruct,
 			// baseObject overhead
-			newExpected: SizeEmpty,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -384,9 +384,9 @@ func TestArrayBufferObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
 			// baseObject overhead + key/value pair
-			expected: SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}
@@ -419,19 +419,19 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil typed array object",
+			name:        "should have a value of SizeEmptyStruct given a nil typed array object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name: "should have a value of SizeEmpty given an empty typed array object",
+			name: "should have a value of SizeEmptyStruct given an empty typed array object",
 			val:  &typedArrayObject{},
 			// typedArrayObject overhead + nil baseObject overhead
-			expected: SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + nil baseObject overhead
-			newExpected: SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -440,9 +440,9 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{},
 			},
 			// typedArrayObject overhead + baseObject overhead
-			expected: SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + baseObject overhead
-			newExpected: SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -451,9 +451,9 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
 			// typedArrayObject overhead + baseObject overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 		{
@@ -464,18 +464,18 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 		{
 			name: "should account for defaultCtor overhead given a typed array object with empty defaultCtor",
 			val:  &typedArrayObject{defaultCtor: &Object{}},
 			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead
-			expected: SizeEmpty + SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -486,9 +486,9 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}
@@ -521,19 +521,19 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil data view object",
+			name:        "should have a value of SizeEmptyStruct given a nil data view object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name: "should have a value of SizeEmpty given an empty data view object",
+			name: "should have a value of SizeEmptyStruct given an empty data view object",
 			val:  &dataViewObject{},
 			// typedArrayObject overhead + nil baseObject overhead
-			expected: SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + nil baseObject overhead
-			newExpected: SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -542,9 +542,9 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{},
 			},
 			// typedArrayObject overhead + baseObject overhead
-			expected: SizeEmpty + SizeEmpty,
+			expected: SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + baseObject overhead
-			newExpected: SizeEmpty + SizeEmpty,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -553,9 +553,9 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
 			// typedArrayObject overhead + baseObject overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 		{
@@ -566,9 +566,9 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 				},
 			},
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
-			expected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
-			newExpected: SizeEmpty + SizeEmpty + SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -514,27 +514,27 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 
 func TestDataViewObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *dataViewObject
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *dataViewObject
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil data view object",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil data view object",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should have a value of SizeEmptyStruct given an empty data view object",
 			val:  &dataViewObject{},
 			// typedArrayObject overhead + nil baseObject overhead
-			expected: SizeEmptyStruct + SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + nil baseObject overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for baseObject overhead given a data view object with empty baseObject",
@@ -542,10 +542,10 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{},
 			},
 			// typedArrayObject overhead + baseObject overhead
-			expected: SizeEmptyStruct + SizeEmptyStruct,
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// typedArrayObject overhead + baseObject overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for baseObject overhead and values given a data view object with non-empty baseObject",
@@ -553,10 +553,10 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
 			// typedArrayObject overhead + baseObject overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 		{
 			name: "should account for arrayBufferObject overhead and values given a data view object with non-empty viewedArrayBuf",
@@ -566,10 +566,10 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 				},
 			},
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 	}
 
@@ -582,11 +582,11 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/value.go
+++ b/value.go
@@ -121,11 +121,11 @@ type Value interface {
 }
 
 const (
-	SizeBool   = uint64(unsafe.Sizeof(true))
-	SizeNumber = uint64(unsafe.Sizeof(float64(0)))
-	SizeInt32  = uint64(unsafe.Sizeof(int32(0)))
-	SizeInt    = uint64(unsafe.Sizeof(int(0)))
-	SizeEmpty  = uint64(unsafe.Sizeof((*baseObject)(nil)))
+	SizeBool        = uint64(unsafe.Sizeof(true))
+	SizeNumber      = uint64(unsafe.Sizeof(float64(0)))
+	SizeInt32       = uint64(unsafe.Sizeof(int32(0)))
+	SizeInt         = uint64(unsafe.Sizeof(int(0)))
+	SizeEmptyStruct = uint64(unsafe.Sizeof((*baseObject)(nil)))
 	// SizeString allows us to take into account the 16 additional bytes
 	// for any string type in go including the pointer to the start of
 	// the string data and the length of the string
@@ -572,7 +572,7 @@ func (n valueNull) IsObject() bool {
 }
 
 func (n valueNull) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	return SizeEmpty, SizeEmpty, nil
+	return SizeEmptyStruct, SizeEmptyStruct, nil
 }
 
 func (u valueUndefined) toString() valueString {
@@ -766,7 +766,7 @@ func (p *valueProperty) hash(*maphash.Hash) uint64 {
 
 func (p *valueProperty) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if p == nil {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
 
 	if p.value != nil {
@@ -1165,7 +1165,7 @@ func (o *Object) hash(*maphash.Hash) uint64 {
 
 func (o *Object) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || o.self == nil {
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	}
 
 	if o.__wrapped != nil {
@@ -1176,15 +1176,15 @@ func (o *Object) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage ui
 
 	switch x := o.self.(type) {
 	case *objectGoReflect:
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	case *objectGoMapReflect:
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	case *objectGoMapSimple:
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	case *objectGoSlice:
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	case *objectGoSliceReflect:
-		return SizeEmpty, SizeEmpty, nil
+		return SizeEmptyStruct, SizeEmptyStruct, nil
 	default:
 		r, ok := x.(MemUsageReporter)
 		if !ok {

--- a/value.go
+++ b/value.go
@@ -126,7 +126,7 @@ const (
 	SizeInt32  = uint64(unsafe.Sizeof(int32(0)))
 	SizeInt    = uint64(unsafe.Sizeof(int(0)))
 	SizeEmpty  = uint64(unsafe.Sizeof((*baseObject)(nil)))
-	// SizeString allows us to take into account the 2 additional bytes
+	// SizeString allows us to take into account the 16 additional bytes
 	// for any string type in go including the pointer to the start of
 	// the string data and the length of the string
 	SizeString = uint64(unsafe.Sizeof(""))

--- a/value.go
+++ b/value.go
@@ -126,6 +126,7 @@ const (
 	SizeInt32       = uint64(unsafe.Sizeof(int32(0)))
 	SizeInt         = uint64(unsafe.Sizeof(int(0)))
 	SizeEmptyStruct = uint64(unsafe.Sizeof((*baseObject)(nil)))
+	SizeEmptySlice  = uint64(unsafe.Sizeof([]Value{}))
 	// SizeString allows us to take into account the 16 additional bytes
 	// for any string type in go including the pointer to the start of
 	// the string data and the length of the string

--- a/value.go
+++ b/value.go
@@ -226,8 +226,8 @@ func fToStr(num float64, mode ftoa.FToStrMode, prec int) string {
 	return string(ftoa.FToStr(num, mode, prec, buf1[:0]))
 }
 
-func (i valueInt) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeNumber, nil
+func (i valueInt) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeNumber, SizeNumber, nil
 }
 
 func (i valueInt) assertInt() (int, bool) {
@@ -359,8 +359,8 @@ func (i valueInt) hash(*maphash.Hash) uint64 {
 	return uint64(i)
 }
 
-func (o valueBool) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeBool, nil
+func (o valueBool) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeBool, SizeBool, nil
 }
 
 func (b valueBool) ToInt() int {
@@ -571,8 +571,8 @@ func (n valueNull) IsObject() bool {
 	return false
 }
 
-func (n valueNull) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeEmpty, nil
+func (n valueNull) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeEmpty, SizeEmpty, nil
 }
 
 func (u valueUndefined) toString() valueString {
@@ -764,33 +764,39 @@ func (p *valueProperty) hash(*maphash.Hash) uint64 {
 	panic("valueProperty should never be used in maps or sets")
 }
 
-func (p *valueProperty) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	total := uint64(0)
+func (p *valueProperty) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if p == nil {
+		return SizeEmpty, SizeEmpty, err
+	}
+
 	if p.value != nil {
-		inc, err := p.value.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := p.value.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	if p.getterFunc != nil {
-		inc, err := p.getterFunc.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := p.getterFunc.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	if p.setterFunc != nil {
-		inc, err := p.setterFunc.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := p.setterFunc.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
 func (p *valueProperty) ToInt() int {
@@ -847,8 +853,8 @@ func floatToIntClip(n float64) int64 {
 	return int64(n)
 }
 
-func (f valueFloat) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return SizeNumber, nil
+func (f valueFloat) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return SizeNumber, SizeNumber, nil
 }
 
 func (f valueFloat) ToInt() int {
@@ -1157,33 +1163,32 @@ func (o *Object) hash(*maphash.Hash) uint64 {
 	return o.getId()
 }
 
-func (o *Object) MemUsage(ctx *MemUsageContext) (uint64, error) {
+func (o *Object) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if o == nil || o.self == nil {
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	}
 
 	if o.__wrapped != nil {
-		nativeMem, ok := ctx.NativeMemUsage(o.__wrapped)
-		if ok {
-			return nativeMem, nil
+		if nativeMem, ok := ctx.NativeMemUsage(o.__wrapped); ok {
+			return nativeMem, nativeMem, nil
 		}
 	}
 
 	switch x := o.self.(type) {
 	case *objectGoReflect:
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	case *objectGoMapReflect:
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	case *objectGoMapSimple:
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	case *objectGoSlice:
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	case *objectGoSliceReflect:
-		return SizeEmpty, nil
+		return SizeEmpty, SizeEmpty, nil
 	default:
 		r, ok := x.(MemUsageReporter)
 		if !ok {
-			return 0, nil
+			return 0, 0, nil
 		}
 		return r.MemUsage(ctx)
 	}
@@ -1471,8 +1476,8 @@ func (o valueUnresolved) hash(*maphash.Hash) uint64 {
 	return 0
 }
 
-func (o valueUnresolved) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return uint64(len(o.ref)), nil
+func (o valueUnresolved) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return uint64(len(o.ref)), uint64(len(o.ref)) + SizeString, nil
 }
 
 func (o valueUnresolved) ToInt() int {
@@ -1632,8 +1637,8 @@ func (s *Symbol) hash(*maphash.Hash) uint64 {
 	return uint64(s.h)
 }
 
-func (s *Symbol) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	return 0, nil
+func (s *Symbol) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	return s.desc.MemUsage(ctx)
 }
 
 func exportValue(v Value, ctx *objectExportCtx) interface{} {

--- a/value.go
+++ b/value.go
@@ -126,6 +126,10 @@ const (
 	SizeInt32  = uint64(unsafe.Sizeof(int32(0)))
 	SizeInt    = uint64(unsafe.Sizeof(int(0)))
 	SizeEmpty  = uint64(unsafe.Sizeof((*baseObject)(nil)))
+	// SizeString allows us to take into account the 2 additional bytes
+	// for any string type in go including the pointer to the start of
+	// the string data and the length of the string
+	SizeString = uint64(unsafe.Sizeof(""))
 )
 
 type valueContainer interface {

--- a/value.go
+++ b/value.go
@@ -117,7 +117,7 @@ type Value interface {
 
 	hash(hasher *maphash.Hash) uint64
 
-	MemUsage(ctx *MemUsageContext) (uint64, error)
+	MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error)
 }
 
 const (

--- a/value_test.go
+++ b/value_test.go
@@ -68,8 +68,8 @@ func TestValueMemUsage(t *testing.T) {
 		{
 			name:        "should have a value of SizeNumber given a valueInt",
 			val:         valueInt(99),
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -80,10 +80,10 @@ func TestValueMemUsage(t *testing.T) {
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given a valueNull",
+			name:        "should have a value of SizeEmptyStruct given a valueNull",
 			val:         valueNull{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -137,10 +137,10 @@ func TestValuePropertyMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given nil valueProperty",
+			name:        "should have a value of SizeEmptyStruct given nil valueProperty",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -157,8 +157,8 @@ func TestValuePropertyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expected:    SizeEmpty + SizeEmpty + 4,
-			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString),
+			expected:    SizeEmptyStruct + SizeEmptyStruct + 4,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
 			errExpected: nil,
 		},
 		{
@@ -168,8 +168,8 @@ func TestValuePropertyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expected:    SizeEmpty + SizeEmpty + 4,
-			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString),
+			expected:    SizeEmptyStruct + SizeEmptyStruct + 4,
+			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
 			errExpected: nil,
 		},
 	}
@@ -202,17 +202,17 @@ func TestObjectMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given nil Object",
+			name:        "should have a value of SizeEmptyStruct given nil Object",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty Object with nil self",
+			name:        "should have a value of SizeEmptyStruct given an empty Object with nil self",
 			val:         &Object{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -223,49 +223,49 @@ func TestObjectMemUsage(t *testing.T) {
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an Object with self of type objectGoReflect",
+			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoReflect",
 			val:         &Object{self: &objectGoReflect{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an Object with self of type objectGoMapReflect",
+			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapReflect",
 			val:         &Object{self: &objectGoMapReflect{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an Object with self of type objectGoMapSimple",
+			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapSimple",
 			val:         &Object{self: &objectGoMapSimple{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an Object with self of type objectGoSlice",
+			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoSlice",
 			val:         &Object{self: &objectGoSlice{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an Object with self of type objectGoSliceReflect",
+			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoSliceReflect",
 			val:         &Object{self: &objectGoSliceReflect{}},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name: "should have a value of SizeEmpty given an Object with self of type objectGoSliceReflect",
+			name: "should have a value of SizeEmptyStruct given an Object with self of type objectGoSliceReflect",
 			val: &Object{
 				self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
 			// baseObject overhead + value
-			expected: SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + value with string overhead
-			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -2,6 +2,8 @@ package goja
 
 import (
 	"testing"
+
+	"github.com/dop251/goja/unistring"
 )
 
 func TestIntSameAsInt(t *testing.T) {
@@ -52,5 +54,237 @@ func TestFloatArrayIncludes(t *testing.T) {
 	}
 	if !res.SameAs(valueBool(true)) {
 		t.Fatal("value not found in array")
+	}
+}
+
+func TestValueMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         MemUsageReporter
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeNumber given a valueInt",
+			val:         valueInt(99),
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeBool given a valueBool",
+			val:         valueBool(true),
+			expected:    SizeBool,
+			newExpected: SizeBool,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given a valueNull",
+			val:         valueNull{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeNumber given a valueFloat",
+			val:         valueFloat(3.3),
+			expected:    SizeNumber,
+			newExpected: SizeNumber,
+			errExpected: nil,
+		},
+		{
+			name:        "should account for ref given a valueUnresolved",
+			val:         valueUnresolved{ref: "test"},
+			expected:    4,
+			newExpected: 4 + SizeString,
+			errExpected: nil,
+		},
+		{
+			name:        "should account for desc given a Symbol",
+			val:         &Symbol{desc: newStringValue("test")},
+			expected:    4,
+			newExpected: 4 + SizeString,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestValuePropertyMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *valueProperty
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given nil valueProperty",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should account for value given a valueProperty with non-empty value",
+			val:         &valueProperty{value: valueInt(99)},
+			expected:    SizeInt,
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for getterFunc given a valueProperty with non-empty getterFunc",
+			val: &valueProperty{
+				getterFunc: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			expected:    SizeEmpty + SizeEmpty + 4,
+			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString),
+			errExpected: nil,
+		},
+		{
+			name: "should account for setterFunc given a valueProperty with non-empty setterFunc",
+			val: &valueProperty{
+				setterFunc: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			expected:    SizeEmpty + SizeEmpty + 4,
+			newExpected: SizeEmpty + SizeEmpty + (4 + SizeString),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestObjectMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *Object
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given nil Object",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty Object with nil self",
+			val:         &Object{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should account for __wrapped given an Object with non-empty __wrapped",
+			val:         &Object{__wrapped: 99},
+			expected:    SizeInt,
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an Object with self of type objectGoReflect",
+			val:         &Object{self: &objectGoReflect{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an Object with self of type objectGoMapReflect",
+			val:         &Object{self: &objectGoMapReflect{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an Object with self of type objectGoMapSimple",
+			val:         &Object{self: &objectGoMapSimple{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an Object with self of type objectGoSlice",
+			val:         &Object{self: &objectGoSlice{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an Object with self of type objectGoSliceReflect",
+			val:         &Object{self: &objectGoSliceReflect{}},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should have a value of SizeEmpty given an Object with self of type objectGoSliceReflect",
+			val: &Object{
+				self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+			},
+			// baseObject overhead + value
+			expected: SizeEmpty + (4 + SizeInt),
+			// baseObject overhead + value with string overhead
+			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -59,53 +59,53 @@ func TestFloatArrayIncludes(t *testing.T) {
 
 func TestValueMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         MemUsageReporter
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            MemUsageReporter
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeNumber given a valueInt",
-			val:         valueInt(99),
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeNumber given a valueInt",
+			val:            valueInt(99),
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeBool given a valueBool",
-			val:         valueBool(true),
-			expected:    SizeBool,
-			newExpected: SizeBool,
-			errExpected: nil,
+			name:           "should have a value of SizeBool given a valueBool",
+			val:            valueBool(true),
+			expectedMem:    SizeBool,
+			expectedNewMem: SizeBool,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given a valueNull",
-			val:         valueNull{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a valueNull",
+			val:            valueNull{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeNumber given a valueFloat",
-			val:         valueFloat(3.3),
-			expected:    SizeNumber,
-			newExpected: SizeNumber,
-			errExpected: nil,
+			name:           "should have a value of SizeNumber given a valueFloat",
+			val:            valueFloat(3.3),
+			expectedMem:    SizeNumber,
+			expectedNewMem: SizeNumber,
+			errExpected:    nil,
 		},
 		{
-			name:        "should account for ref given a valueUnresolved",
-			val:         valueUnresolved{ref: "test"},
-			expected:    4,
-			newExpected: 4 + SizeString,
-			errExpected: nil,
+			name:           "should account for ref given a valueUnresolved",
+			val:            valueUnresolved{ref: "test"},
+			expectedMem:    4,
+			expectedNewMem: 4 + SizeString,
+			errExpected:    nil,
 		},
 		{
-			name:        "should account for desc given a Symbol",
-			val:         &Symbol{desc: newStringValue("test")},
-			expected:    4,
-			newExpected: 4 + SizeString,
-			errExpected: nil,
+			name:           "should account for desc given a Symbol",
+			val:            &Symbol{desc: newStringValue("test")},
+			expectedMem:    4,
+			expectedNewMem: 4 + SizeString,
+			errExpected:    nil,
 		},
 	}
 
@@ -118,11 +118,11 @@ func TestValueMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -130,25 +130,25 @@ func TestValueMemUsage(t *testing.T) {
 
 func TestValuePropertyMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *valueProperty
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *valueProperty
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given nil valueProperty",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given nil valueProperty",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should account for value given a valueProperty with non-empty value",
-			val:         &valueProperty{value: valueInt(99)},
-			expected:    SizeInt,
-			newExpected: SizeInt,
-			errExpected: nil,
+			name:           "should account for value given a valueProperty with non-empty value",
+			val:            &valueProperty{value: valueInt(99)},
+			expectedMem:    SizeInt,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for getterFunc given a valueProperty with non-empty getterFunc",
@@ -157,9 +157,9 @@ func TestValuePropertyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expected:    SizeEmptyStruct + SizeEmptyStruct + 4,
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
-			errExpected: nil,
+			expectedMem:    SizeEmptyStruct + SizeEmptyStruct + 4,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
+			errExpected:    nil,
 		},
 		{
 			name: "should account for setterFunc given a valueProperty with non-empty setterFunc",
@@ -168,9 +168,9 @@ func TestValuePropertyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expected:    SizeEmptyStruct + SizeEmptyStruct + 4,
-			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
-			errExpected: nil,
+			expectedMem:    SizeEmptyStruct + SizeEmptyStruct + 4,
+			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
+			errExpected:    nil,
 		},
 	}
 
@@ -183,11 +183,11 @@ func TestValuePropertyMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -195,67 +195,67 @@ func TestValuePropertyMemUsage(t *testing.T) {
 
 func TestObjectMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *Object
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *Object
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given nil Object",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given nil Object",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty Object with nil self",
-			val:         &Object{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty Object with nil self",
+			val:            &Object{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should account for __wrapped given an Object with non-empty __wrapped",
-			val:         &Object{__wrapped: 99},
-			expected:    SizeInt,
-			newExpected: SizeInt,
-			errExpected: nil,
+			name:           "should account for __wrapped given an Object with non-empty __wrapped",
+			val:            &Object{__wrapped: 99},
+			expectedMem:    SizeInt,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoReflect",
-			val:         &Object{self: &objectGoReflect{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoReflect",
+			val:            &Object{self: &objectGoReflect{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapReflect",
-			val:         &Object{self: &objectGoMapReflect{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapReflect",
+			val:            &Object{self: &objectGoMapReflect{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapSimple",
-			val:         &Object{self: &objectGoMapSimple{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapSimple",
+			val:            &Object{self: &objectGoMapSimple{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoSlice",
-			val:         &Object{self: &objectGoSlice{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoSlice",
+			val:            &Object{self: &objectGoSlice{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an Object with self of type objectGoSliceReflect",
-			val:         &Object{self: &objectGoSliceReflect{}},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoSliceReflect",
+			val:            &Object{self: &objectGoSliceReflect{}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should have a value of SizeEmptyStruct given an Object with self of type objectGoSliceReflect",
@@ -263,10 +263,10 @@ func TestObjectMemUsage(t *testing.T) {
 				self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
 			// baseObject overhead + value
-			expected: SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + value with string overhead
-			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 	}
 
@@ -279,11 +279,11 @@ func TestObjectMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/vm.go
+++ b/vm.go
@@ -45,34 +45,41 @@ type vmContext struct {
 	args      int
 }
 
-func (vc *vmContext) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	total := SizeEmpty
+func (vc *vmContext) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if vc == nil {
+		return SizeEmpty, SizeEmpty, err
+	}
+	memUsage = SizeEmpty
+	newMemUsage = SizeEmpty
 
 	if vc.newTarget != nil {
-		inc, err := vc.newTarget.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := vc.newTarget.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	if vc.stash != nil {
-		inc, err := vc.stash.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := vc.stash.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
 	if vc.prg != nil {
-		inc, err := vc.prg.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := vc.prg.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }
 
 type iterStackItem struct {
@@ -5512,19 +5519,19 @@ func (r *getPrivateRefId) exec(vm *vm) {
 	vm.pc++
 }
 
-func (stack valueStack) MemUsage(ctx *MemUsageContext) (uint64, error) {
-	total := uint64(0)
-	for _, self := range stack {
-		if self == nil {
+func (s valueStack) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	for _, val := range s {
+		if val == nil {
 			continue
 		}
 
-		inc, err := self.MemUsage(ctx)
-		total += inc
+		inc, newInc, err := val.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
 		if err != nil {
-			return total, err
+			return memUsage, newMemUsage, err
 		}
 	}
 
-	return total, nil
+	return memUsage, newMemUsage, nil
 }

--- a/vm.go
+++ b/vm.go
@@ -47,10 +47,10 @@ type vmContext struct {
 
 func (vc *vmContext) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
 	if vc == nil {
-		return SizeEmpty, SizeEmpty, err
+		return SizeEmptyStruct, SizeEmptyStruct, err
 	}
-	memUsage = SizeEmpty
-	newMemUsage = SizeEmpty
+	memUsage = SizeEmptyStruct
+	newMemUsage = SizeEmptyStruct
 
 	if vc.newTarget != nil {
 		inc, newInc, err := vc.newTarget.MemUsage(ctx)

--- a/vm.go
+++ b/vm.go
@@ -535,6 +535,41 @@ func (s *stash) deleteBinding(name unistring.String) {
 	delete(s.names, name)
 }
 
+func (s *stash) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
+	if s == nil || ctx.IsStashVisited(s) {
+		return memUsage, newMemUsage, err
+	}
+	ctx.VisitStash(s)
+
+	if s.obj != nil {
+		inc, newInc, err := s.obj.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
+		if err != nil {
+			return memUsage, newMemUsage, err
+		}
+	}
+
+	if s.outer != nil {
+		inc, newInc, err := s.outer.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
+		if err != nil {
+			return memUsage, newMemUsage, err
+		}
+	}
+	if len(s.values) > 0 {
+		inc, newInc, err := s.values.MemUsage(ctx)
+		memUsage += inc
+		newMemUsage += newInc
+		if err != nil {
+			return memUsage, newMemUsage, err
+		}
+	}
+
+	return memUsage, newMemUsage, nil
+}
+
 func (vm *vm) newStash() {
 	vm.stash = &stash{
 		outer: vm.stash,

--- a/vm_test.go
+++ b/vm_test.go
@@ -336,34 +336,34 @@ func TestFloatToValue(t *testing.T) {
 
 func TestValueStackMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         valueStack
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            valueStack
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should account for no memory usage given an empty value stack",
-			val:         []Value{},
-			expected:    0,
-			newExpected: 0,
-			errExpected: nil,
+			name:           "should account for no memory usage given an empty value stack",
+			val:            []Value{},
+			expectedMem:    0,
+			expectedNewMem: 0,
+			errExpected:    nil,
 		},
 		{
-			name:        "should account for no memory usage given a value stack with nil",
-			val:         []Value{nil},
-			expected:    0,
-			newExpected: 0,
-			errExpected: nil,
+			name:           "should account for no memory usage given a value stack with nil",
+			val:            []Value{nil},
+			expectedMem:    0,
+			expectedNewMem: 0,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for each value given a non-empty value stack",
 			val:  []Value{valueInt(99)},
 			// value
-			expected: SizeInt,
+			expectedMem: SizeInt,
 			// value
-			newExpected: SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 	}
 
@@ -376,11 +376,11 @@ func TestValueStackMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -388,43 +388,43 @@ func TestValueStackMemUsage(t *testing.T) {
 
 func TestVMContextMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *vmContext
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *vmContext
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of SizeEmptyStruct given a nil vmContext",
-			val:         nil,
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given a nil vmContext",
+			val:            nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of SizeEmptyStruct given an empty vmContext",
-			val:         &vmContext{},
-			expected:    SizeEmptyStruct,
-			newExpected: SizeEmptyStruct,
-			errExpected: nil,
+			name:           "should have a value of SizeEmptyStruct given an empty vmContext",
+			val:            &vmContext{},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for newTarget given a vmContext with non-empty newTarget",
 			val:  &vmContext{newTarget: valueInt(99)},
 			// vmContext overhead + newTarget value
-			expected: SizeEmptyStruct + SizeInt,
+			expectedMem: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + newTarget value
-			newExpected: SizeEmptyStruct + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for stash given a vmContext with non-empty stash",
 			val:  &vmContext{stash: &stash{values: []Value{valueInt(99)}}},
 			// vmContext overhead + stash value
-			expected: SizeEmptyStruct + SizeInt,
+			expectedMem: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + stash value
-			newExpected: SizeEmptyStruct + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for stash given a vmContext with non-empty stash",
@@ -432,10 +432,10 @@ func TestVMContextMemUsage(t *testing.T) {
 				values: []Value{valueInt(99)},
 			}},
 			// vmContext overhead + prg value
-			expected: SizeEmptyStruct + SizeInt,
+			expectedMem: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + prg value
-			newExpected: SizeEmptyStruct + SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
 		},
 	}
 
@@ -448,11 +448,11 @@ func TestVMContextMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}
@@ -460,25 +460,25 @@ func TestVMContextMemUsage(t *testing.T) {
 
 func TestStashMemUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		val         *stash
-		expected    uint64
-		newExpected uint64
-		errExpected error
+		name           string
+		val            *stash
+		expectedMem    uint64
+		expectedNewMem uint64
+		errExpected    error
 	}{
 		{
-			name:        "should have a value of 0 given a nil stash",
-			val:         nil,
-			expected:    0,
-			newExpected: 0,
-			errExpected: nil,
+			name:           "should have a value of 0 given a nil stash",
+			val:            nil,
+			expectedMem:    0,
+			expectedNewMem: 0,
+			errExpected:    nil,
 		},
 		{
-			name:        "should have a value of 0 given an empty stash",
-			val:         &stash{},
-			expected:    0,
-			newExpected: 0,
-			errExpected: nil,
+			name:           "should have a value of 0 given an empty stash",
+			val:            &stash{},
+			expectedMem:    0,
+			expectedNewMem: 0,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for obj given a stash with non-empty obj",
@@ -488,28 +488,28 @@ func TestStashMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject overhead + obj value
-			expected: SizeEmptyStruct + (4 + SizeInt),
+			expectedMem: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + obj value with string overhead
-			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
-			errExpected: nil,
+			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			errExpected:    nil,
 		},
 		{
 			name: "should account for values given a stash with non-empty values",
 			val:  &stash{values: []Value{valueInt(99)}},
 			// value
-			expected: SizeInt,
+			expectedMem: SizeInt,
 			// value
-			newExpected: SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 		{
 			name: "should account for outer given a stash with non-empty outer",
 			val:  &stash{outer: &stash{values: []Value{valueInt(99)}}},
 			// outer stash value
-			expected: SizeInt,
+			expectedMem: SizeInt,
 			// outer stash value
-			newExpected: SizeInt,
-			errExpected: nil,
+			expectedNewMem: SizeInt,
+			errExpected:    nil,
 		},
 	}
 
@@ -522,11 +522,11 @@ func TestStashMemUsage(t *testing.T) {
 			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
 				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
 			}
-			if total != tc.expected {
-				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			if total != tc.expectedMem {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
-			if newTotal != tc.newExpected {
-				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			if newTotal != tc.expectedNewMem {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.expectedNewMem)
 			}
 		})
 	}

--- a/vm_test.go
+++ b/vm_test.go
@@ -395,35 +395,35 @@ func TestVMContextMemUsage(t *testing.T) {
 		errExpected error
 	}{
 		{
-			name:        "should have a value of SizeEmpty given a nil vmContext",
+			name:        "should have a value of SizeEmptyStruct given a nil vmContext",
 			val:         nil,
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
-			name:        "should have a value of SizeEmpty given an empty vmContext",
+			name:        "should have a value of SizeEmptyStruct given an empty vmContext",
 			val:         &vmContext{},
-			expected:    SizeEmpty,
-			newExpected: SizeEmpty,
+			expected:    SizeEmptyStruct,
+			newExpected: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "should account for newTarget given a vmContext with non-empty newTarget",
 			val:  &vmContext{newTarget: valueInt(99)},
 			// vmContext overhead + newTarget value
-			expected: SizeEmpty + SizeInt,
+			expected: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + newTarget value
-			newExpected: SizeEmpty + SizeInt,
+			newExpected: SizeEmptyStruct + SizeInt,
 			errExpected: nil,
 		},
 		{
 			name: "should account for stash given a vmContext with non-empty stash",
 			val:  &vmContext{stash: &stash{values: []Value{valueInt(99)}}},
 			// vmContext overhead + stash value
-			expected: SizeEmpty + SizeInt,
+			expected: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + stash value
-			newExpected: SizeEmpty + SizeInt,
+			newExpected: SizeEmptyStruct + SizeInt,
 			errExpected: nil,
 		},
 		{
@@ -432,9 +432,9 @@ func TestVMContextMemUsage(t *testing.T) {
 				values: []Value{valueInt(99)},
 			}},
 			// vmContext overhead + prg value
-			expected: SizeEmpty + SizeInt,
+			expected: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + prg value
-			newExpected: SizeEmpty + SizeInt,
+			newExpected: SizeEmptyStruct + SizeInt,
 			errExpected: nil,
 		},
 	}
@@ -488,9 +488,9 @@ func TestStashMemUsage(t *testing.T) {
 				},
 			},
 			// baseObject overhead + obj value
-			expected: SizeEmpty + (4 + SizeInt),
+			expected: SizeEmptyStruct + (4 + SizeInt),
 			// baseObject overhead + obj value with string overhead
-			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
 		},
 		{

--- a/vm_test.go
+++ b/vm_test.go
@@ -333,3 +333,127 @@ func TestFloatToValue(t *testing.T) {
 		}
 	}
 }
+
+func TestValueStackMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         valueStack
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should account for no memory usage given an empty value stack",
+			val:         []Value{},
+			expected:    0,
+			newExpected: 0,
+			errExpected: nil,
+		},
+		{
+			name:        "should account for no memory usage given a value stack with nil",
+			val:         []Value{nil},
+			expected:    0,
+			newExpected: 0,
+			errExpected: nil,
+		},
+		{
+			name: "should account for each value given a non-empty value stack",
+			val:  []Value{valueInt(99)},
+			// value
+			expected: SizeInt,
+			// value
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}
+
+func TestVMContextMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *vmContext
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of SizeEmpty given a nil vmContext",
+			val:         nil,
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of SizeEmpty given an empty vmContext",
+			val:         &vmContext{},
+			expected:    SizeEmpty,
+			newExpected: SizeEmpty,
+			errExpected: nil,
+		},
+		{
+			name: "should account for newTarget given a vmContext with non-empty newTarget",
+			val:  &vmContext{newTarget: valueInt(99)},
+			// vmContext overhead + newTarget value
+			expected: SizeEmpty + SizeInt,
+			// vmContext overhead + newTarget value
+			newExpected: SizeEmpty + SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for stash given a vmContext with non-empty stash",
+			val:  &vmContext{stash: &stash{values: []Value{valueInt(99)}}},
+			// vmContext overhead + stash value
+			expected: SizeEmpty + SizeInt,
+			// vmContext overhead + stash value
+			newExpected: SizeEmpty + SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for stash given a vmContext with non-empty stash",
+			val: &vmContext{prg: &Program{
+				values: []Value{valueInt(99)},
+			}},
+			// vmContext overhead + prg value
+			expected: SizeEmpty + SizeInt,
+			// vmContext overhead + prg value
+			newExpected: SizeEmpty + SizeInt,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}

--- a/vm_test.go
+++ b/vm_test.go
@@ -457,3 +457,77 @@ func TestVMContextMemUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestStashMemUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         *stash
+		expected    uint64
+		newExpected uint64
+		errExpected error
+	}{
+		{
+			name:        "should have a value of 0 given a nil stash",
+			val:         nil,
+			expected:    0,
+			newExpected: 0,
+			errExpected: nil,
+		},
+		{
+			name:        "should have a value of 0 given an empty stash",
+			val:         &stash{},
+			expected:    0,
+			newExpected: 0,
+			errExpected: nil,
+		},
+		{
+			name: "should account for obj given a stash with non-empty obj",
+			val: &stash{
+				obj: &Object{
+					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+				},
+			},
+			// baseObject overhead + obj value
+			expected: SizeEmpty + (4 + SizeInt),
+			// baseObject overhead + obj value with string overhead
+			newExpected: SizeEmpty + (4 + SizeString + SizeInt),
+			errExpected: nil,
+		},
+		{
+			name: "should account for values given a stash with non-empty values",
+			val:  &stash{values: []Value{valueInt(99)}},
+			// value
+			expected: SizeInt,
+			// value
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+		{
+			name: "should account for outer given a stash with non-empty outer",
+			val:  &stash{outer: &stash{values: []Value{valueInt(99)}}},
+			// outer stash value
+			expected: SizeInt,
+			// outer stash value
+			newExpected: SizeInt,
+			errExpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			if err != tc.errExpected {
+				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if err != nil && tc.errExpected != nil && err.Error() != tc.errExpected.Error() {
+				t.Fatalf("Errors do not match. Actual: %v Expected: %v", err, tc.errExpected)
+			}
+			if total != tc.expected {
+				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expected)
+			}
+			if newTotal != tc.newExpected {
+				t.Fatalf("Unexpected new memory return. Actual: %v Expected: %v", newTotal, tc.newExpected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a small ma pretty important change. Strings in go have an overhead of 16bytes, currently an empty string adds up to 0 bytes from the way we calculate memory usage which is not correct. With this change every native string or object key (which are also strings) will also account for the overhead defined in `SizeString`.

**EDIT**

To understand the impact of this change all `MemUsage` functions return the existing value + an adjusted one. This will help us understand the impact of such a change before we roll it out to customers. I split the commit logically for easier review but beware that the whole test suite only passes with the last commits.

* Original commit that has been already reviewed
* Update the interfaces to the new MemUsage signature
* Update every single MemUsage function to use the new signature + add tests
* A small refactor based on Nick's comment

Generally I noticed a few missing `nil` checks and other incorrect MemUsage functions, the diff should be easy to spot from the single commits.
