### PR TITLE
BAAS-23655: Remove internal goja tick counter

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -544,7 +543,6 @@ func (vm *vm) init() {
 func (vm *vm) run() {
 	vm.halt = false
 	interrupted := false
-	ticks := 0
 	for !vm.halt {
 		vm.r.waitOneTick()
 		if interrupted = atomic.LoadUint32(&vm.interrupted) != 0; interrupted {
@@ -583,11 +581,6 @@ func (vm *vm) run() {
 			}()
 		} else {
 			vm.prg.code[vm.pc].exec(vm)
-		}
-		ticks++
-		if ticks > 10000 {
-			runtime.Gosched()
-			ticks = 0
 		}
 	}
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/BAAS-23655

This rolls back this [commit](https://github.com/Calvinnix/goja/commit/f95411d186f2183429261010a860c604371ac6a7) from the maintainer that was fixing a bug where Runtime.interrupt was never called.

This change would fail `TestRunLoopPreempt` but we haven't ran that test since it was commented out [here](https://github.com/Calvinnix/goja/commit/c84a6965a8e80876c246809bd7e747004402e761)

I'm making an assumption that our custom interrupt logic resolves the need for calling runtime.Gosched periodically. If we see issues, worst case scenario we could add runtime.Gosched inside of waitOneTick.

current
```
goja (realm)$ go test -bench=^BenchmarkEmpty -benchtime 10000000x
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10           10000000              5953 ns/op
PASS
ok      github.com/dop251/goja  60.116s
```

new
```
goja (BAAS-23655_removeInternalGojaTickCounter)$ go test -bench=^BenchmarkEmpty -benchtime 10000000x
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10           10000000              5802 ns/op
PASS
ok      github.com/dop251/goja  58.620s
```

With this change we are seeing ~2.5% performance improvement specifically for the loop in vm.run(). This will get drowned out a bit depending on what customers are doing in their functions, but we will still probably see a nice improvement (see pprof investigation from ticket).