### PR TITLE
BAAS-23656: Remove limiter nil check in waitOneTick method

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -1,9 +1,6 @@
 package goja
 
 import (
-	"context"
-	"strings"
-
 	"golang.org/x/time/rate"
 )
 
@@ -15,36 +12,6 @@ func (self *Runtime) SetRateLimiter(limiter *rate.Limiter) {
 	}
 
 	self.fillBucket()
-}
-
-// NOTE: we should try to avoid making expensive operations within this
-// function since it gets called millions of times per second.
-func (self *Runtime) waitOneTick() {
-	self.ticks++
-
-	if self.limiterTicksLeft > 0 {
-		self.limiterTicksLeft--
-		return
-	}
-	self.fillBucket()
-
-	ctx := self.vm.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	if waitErr := self.limiter.WaitN(ctx, self.limiterTicksLeft); waitErr != nil {
-		if self.vm.ctx == nil {
-			panic(waitErr)
-		}
-		if ctxErr := self.vm.ctx.Err(); ctxErr != nil {
-			panic(ctxErr)
-		}
-		if strings.Contains(waitErr.Error(), "would exceed") {
-			panic(context.DeadlineExceeded)
-		}
-		panic(waitErr)
-	}
 }
 
 const burstDivisor = 5

--- a/limiter.go
+++ b/limiter.go
@@ -21,9 +21,6 @@ func (self *Runtime) SetRateLimiter(limiter *rate.Limiter) {
 // function since it gets called millions of times per second.
 func (self *Runtime) waitOneTick() {
 	self.ticks++
-	if self.limiter == nil {
-		return
-	}
 
 	if self.limiterTicksLeft > 0 {
 		self.limiterTicksLeft--

--- a/runtime.go
+++ b/runtime.go
@@ -505,7 +505,7 @@ func (r *Runtime) init() {
 		configurable: true,
 	})
 
-	r.SetRateLimiter(rate.NewLimiter(rate.Inf, 1))
+	r.SetRateLimiter(rate.NewLimiter(rate.Inf, maxInt))
 }
 
 func (r *Runtime) typeErrorResult(throw bool, args ...interface{}) {

--- a/runtime.go
+++ b/runtime.go
@@ -504,6 +504,8 @@ func (r *Runtime) init() {
 		accessor:     true,
 		configurable: true,
 	})
+
+	r.SetRateLimiter(rate.NewLimiter(rate.Inf, 1))
 }
 
 func (r *Runtime) typeErrorResult(throw bool, args ...interface{}) {

--- a/vm.go
+++ b/vm.go
@@ -586,7 +586,35 @@ func (vm *vm) run() {
 	vm.halt = false
 	interrupted := false
 	for !vm.halt {
-		vm.r.waitOneTick()
+		// start: wait one tick
+		// NOTE: we should try to avoid making expensive operations within this
+		// loop since it gets called millions of times per second.
+		vm.r.ticks++
+		if vm.r.limiterTicksLeft > 0 {
+			vm.r.limiterTicksLeft--
+		} else {
+			vm.r.fillBucket()
+
+			ctx := vm.r.vm.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			if waitErr := vm.r.limiter.WaitN(ctx, vm.r.limiterTicksLeft); waitErr != nil {
+				if vm.r.vm.ctx == nil {
+					panic(waitErr)
+				}
+				if ctxErr := vm.r.vm.ctx.Err(); ctxErr != nil {
+					panic(ctxErr)
+				}
+				if strings.Contains(waitErr.Error(), "would exceed") {
+					panic(context.DeadlineExceeded)
+				}
+				panic(waitErr)
+			}
+		}
+		// end: wait one tick
+
 		if interrupted = atomic.LoadUint32(&vm.interrupted) != 0; interrupted {
 			vm.interruptLock.Lock()
 			interruptFunc, ok := vm.interruptVal.(func())

--- a/vm.go
+++ b/vm.go
@@ -586,7 +586,6 @@ func (vm *vm) run() {
 	vm.halt = false
 	interrupted := false
 	for !vm.halt {
-		// start: wait one tick
 		// NOTE: we should try to avoid making expensive operations within this
 		// loop since it gets called millions of times per second.
 		vm.r.ticks++
@@ -613,7 +612,6 @@ func (vm *vm) run() {
 				panic(waitErr)
 			}
 		}
-		// end: wait one tick
 
 		if interrupted = atomic.LoadUint32(&vm.interrupted) != 0; interrupted {
 			vm.interruptLock.Lock()

--- a/vm_test.go
+++ b/vm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dop251/goja/parser"
 	"github.com/dop251/goja/unistring"
+	"golang.org/x/time/rate"
 )
 
 func TestTaggedTemplateArgExport(t *testing.T) {
@@ -229,6 +230,7 @@ func BenchmarkEmptyLoop(b *testing.B) {
 	`
 	b.StopTimer()
 	vm := New()
+	vm.SetRateLimiter(rate.NewLimiter(rate.Limit(10_000_000), 250_000))
 	prg := MustCompile("test.js", SCRIPT, false)
 	// prg.dumpCode(log.Printf)
 	b.StartTimer()

--- a/vm_test.go
+++ b/vm_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dop251/goja/parser"
 	"github.com/dop251/goja/unistring"
-	"golang.org/x/time/rate"
 )
 
 func TestTaggedTemplateArgExport(t *testing.T) {
@@ -230,7 +229,6 @@ func BenchmarkEmptyLoop(b *testing.B) {
 	`
 	b.StopTimer()
 	vm := New()
-	vm.SetRateLimiter(rate.NewLimiter(rate.Limit(10_000_000), 250_000))
 	prg := MustCompile("test.js", SCRIPT, false)
 	// prg.dumpCode(log.Printf)
 	b.StartTimer()


### PR DESCRIPTION
https://jira.mongodb.org/browse/BAAS-23656

Benchmark results:

current
```
goja (BAAS-23656_removeSelfLimiterNilCheck)$ go test -bench=BenchmarkEmptyLoop$ -run=$ -benchtime 1000000x
--
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10            1000000              6143 ns/op
PASS
ok      github.com/dop251/goja  6.537s
```

new
```
goja (BAAS-23656_removeSelfLimiterNilCheck)$ go test -bench=BenchmarkEmptyLoop$ -run=$ -benchtime 1000000x
--
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10            1000000              6047 ns/op
PASS
ok      github.com/dop251/goja  6.237s
```

Roughly a 1.5% improvement


Note: there are still a few additional goja tests that I'll need to update to ensure limiter isn't nil, but wanted to gather opinions on this change prior to doing that work.



Edit:
Also inlining the waitOneTick function like Andy suggested gave us a 8.5% improvement

```
goja (BAAS-23656_removeSelfLimiterNilCheck)$ go test -bench=BenchmarkEmptyLoop$ -run=$ -benchtime 1000000x
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10            1000000              5623 ns/op
PASS
ok      github.com/dop251/goja  6.443s
```