### PR TITLE
BAAS-23710: Reduce getFuncName calls in saveCtx

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -786,8 +786,9 @@ func (vm *vm) peek() Value {
 func (vm *vm) saveCtx(ctx *vmContext) {
 	ctx.prg, ctx.stash, ctx.privEnv, ctx.newTarget, ctx.result, ctx.pc, ctx.sb, ctx.args =
 		vm.prg, vm.stash, vm.privEnv, vm.newTarget, vm.result, vm.pc, vm.sb, vm.args
-	if vm.getFuncName() != "" {
-		ctx.funcName = vm.getFuncName()
+	funcName := vm.getFuncName()
+	if funcName != "" {
+		ctx.funcName = funcName
 	} else if ctx.prg != nil && ctx.prg.funcName != "" {
 		ctx.funcName = ctx.prg.funcName
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/BAAS-23710

current
```
goja (BAAS-23710_reduceGetFuncNameCallsInSaveCtx)$ go test -bench=^BenchmarkFib$ -run=^$
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkFib-10                1        4053097750 ns/op
```

new
```
goja (BAAS-23710_reduceGetFuncNameCallsInSaveCtx)$ go test -bench=^BenchmarkFib$ -run=^$
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkFib-10                1        3649985291 ns/op
```

BenchmarkFib saw roughly a 9.9% performance improvement