### PR TITLE
BAAS-23701: reduce allocations in objectproto_toString by avoiding Sprintf usage

### DIFF
--- a/builtin_object.go
+++ b/builtin_object.go
@@ -1,9 +1,5 @@
 package goja
 
-import (
-	"fmt"
-)
-
 func (r *Runtime) builtin_Object(args []Value, newTarget *Object) *Object {
 	if newTarget != nil && newTarget != r.global.Object {
 		proto := r.getPrototypeFromCtor(newTarget, nil, r.global.ObjectPrototype)
@@ -491,7 +487,7 @@ func (r *Runtime) objectproto_toString(call FunctionCall) Value {
 				clsName = str.String()
 			}
 		}
-		return newStringValue(fmt.Sprintf("[object %s]", clsName))
+		return newStringValue("[object " + clsName + "]")
 	}
 }
 


### PR DESCRIPTION
```
goja (BAAS-23701)$ go test -bench=^BenchmarkObjectproto -run=^$ -benchmem
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkObjectproto_toString-10                19064584                62.89 ns/op           40 B/op          2 allocs/op
BenchmarkObjectprotoImproved_toString-10        81820740                14.77 ns/op            0 B/op          0 allocs/op
PASS
```

```
func BenchmarkObjectproto_toString(b *testing.B) {
	clsName := "someclass"
	for i := 0; i < b.N; i++ {
		_ = func(s string) string {
			return fmt.Sprintf("[object %s]", clsName)
		}(clsName)
	}
}

func BenchmarkObjectprotoImproved_toString(b *testing.B) {
	clsName := "someclass"
	for i := 0; i < b.N; i++ {
		_ = func(s string) string {
			return "[object " + clsName + "]"
		}(clsName)
	}
}
```