### PR TITLE
BAAS-24170: Prevent setting rate limiter to nil

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -7,7 +7,7 @@ import (
 // SetRateLimiter sets the rate limiter
 func (self *Runtime) SetRateLimiter(limiter *rate.Limiter) {
 	if limiter == nil {
-		return
+		limiter = rate.NewLimiter(rate.Inf, maxInt)
 	}
 	self.limiter = limiter
 	self.fillBucket()

--- a/limiter.go
+++ b/limiter.go
@@ -6,11 +6,10 @@ import (
 
 // SetRateLimiter sets the rate limiter
 func (self *Runtime) SetRateLimiter(limiter *rate.Limiter) {
-	self.limiter = limiter
 	if limiter == nil {
 		return
 	}
-
+	self.limiter = limiter
 	self.fillBucket()
 }
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -1,0 +1,15 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestSetRateLimiter(t *testing.T) {
+	t.Run("should handle when setting rate limiter to nil", func(t *testing.T) {
+		r := New()
+		r.SetRateLimiter(nil)
+		if r.limiter == nil {
+			t.Fatal("limiter should not be nil")
+		}
+	})
+}


### PR DESCRIPTION
This change just means we can't override the limiter with a nil limiter.

This works now because we are defaulting the limiter [here](https://github.com/Calvinnix/goja/blob/9b379545217111b76b9286649a58ac61685ecd31/runtime.go#L508).