### PR TITLE
BAAS-23857: apply new mem usage everyhere but objectGoSlice and objectGoMapSimple

### DIFF
--- a/array.go
+++ b/array.go
@@ -618,7 +618,7 @@ func (a *arrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsa
 
 	// slice overhead from a.values
 	if a.values != nil {
-		memUsage += 0
+		memUsage += SizeEmptySlice
 		newMemUsage += SizeEmptySlice
 	}
 

--- a/array_test.go
+++ b/array_test.go
@@ -157,8 +157,8 @@ func TestArrayObjectMemUsage(t *testing.T) {
 			name: "mem below threshold given empty slice of values",
 			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
 			ao:   &arrayObject{values: []Value{}},
-			// array overhead + array baseObject
-			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
+			// array overhead + array baseObject + values slice overhead
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice,
 			// array overhead + array baseObject + values slice overhead
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice,
 			errExpected:    nil,
@@ -168,24 +168,20 @@ func TestArrayObjectMemUsage(t *testing.T) {
 			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{
-					vm._newString(newStringValue("key0"), nil),
-					vm._newString(newStringValue("key1"), nil),
-					vm._newString(newStringValue("key2"), nil),
-					vm._newString(newStringValue("key3"), nil),
-					vm._newString(newStringValue("key4"), nil),
-					vm._newString(newStringValue("key5"), nil),
+					vm.ToValue("key0"),
+					vm.ToValue("key1"),
+					vm.ToValue("key2"),
+					vm.ToValue("key3"),
+					vm.ToValue("key4"),
+					vm.ToValue("key5"),
 				},
 			},
-			// array overhead + array baseObject
-			expectedMem: SizeEmptyStruct + SizeEmptyStruct +
-				// (stringObject + baseObject + prop "length") * entries (at 4 we reach the limit)
-				(SizeEmptyStruct+SizeEmptyStruct+6)*4 +
-				// len("keyN") * entries (at 4 we reach the limit)
-				4*4,
+			// array overhead + array baseObject + values slice overhead
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice +
+				// len("keyN") with string overhead * entries (at 4 we reach the limit)
+				(4+SizeString)*4,
 			// array overhead + array baseObject + values slice overhead
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice +
-				// (stringObject + baseObject + prop "length" with string overhead) * entries (at 4 we reach the limit)
-				(SizeEmptyStruct+SizeEmptyStruct+(6+SizeString))*4 +
 				// len("keyN") with string overhead * entries (at 4 we reach the limit)
 				(4+SizeString)*4,
 			errExpected: nil,

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -253,33 +253,33 @@ func TestMapObjectMemUsage(t *testing.T) {
 		expectedNewMem uint64
 		errExpected    error
 	}{
-		// {
-		// 	name: "mem below threshold",
-		// 	mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
-		// 	mo: &mapObject{
-		// 		m: &orderedMap{
-		// 			hashTable: map[uint64]*mapEntry{
-		// 				1: {
-		// 					key:   vm.ToValue("key"),
-		// 					value: vm.ToValue("value"),
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	// baseObject + (len(key) + overhead)  + (len(value) + overhead)
-		// 	expectedMem: SizeEmptyStruct + (3 + SizeString) + (5 + SizeString),
-		// 	// baseObject + (len(key) + overhead) + (len(value) + overhead)
-		// 	expectedNewMem: SizeEmptyStruct + (3 + SizeString) + (5 + SizeString),
-		// 	errExpected:    nil,
-		// },
-		// {
-		// 	name:           "mem is SizeEmptyStruct given a nil map object",
-		// 	mu:             NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
-		// 	mo:             nil,
-		// 	expectedMem:    SizeEmptyStruct,
-		// 	expectedNewMem: SizeEmptyStruct,
-		// 	errExpected:    nil,
-		// },
+		{
+			name: "mem below threshold",
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mo: &mapObject{
+				m: &orderedMap{
+					hashTable: map[uint64]*mapEntry{
+						1: {
+							key:   vm.ToValue("key"),
+							value: vm.ToValue("value"),
+						},
+					},
+				},
+			},
+			// baseObject + (len(key) + overhead)  + (len(value) + overhead)
+			expectedMem: SizeEmptyStruct + (3 + SizeString) + (5 + SizeString),
+			// baseObject + (len(key) + overhead) + (len(value) + overhead)
+			expectedNewMem: SizeEmptyStruct + (3 + SizeString) + (5 + SizeString),
+			errExpected:    nil,
+		},
+		{
+			name:           "mem is SizeEmptyStruct given a nil map object",
+			mu:             NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mo:             nil,
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
+		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
 			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -244,6 +244,7 @@ func BenchmarkMapDeleteJS(b *testing.B) {
 }
 
 func TestMapObjectMemUsage(t *testing.T) {
+	vm := New()
 	tests := []struct {
 		name           string
 		mu             *MemUsageContext
@@ -252,70 +253,70 @@ func TestMapObjectMemUsage(t *testing.T) {
 		expectedNewMem uint64
 		errExpected    error
 	}{
-		{
-			name: "mem below threshold",
-			mu:   NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
-			mo: &mapObject{
-				m: &orderedMap{
-					hashTable: map[uint64]*mapEntry{
-						1: {
-							key:   New()._newString(newStringValue("key"), nil),
-							value: New()._newString(newStringValue("value"), nil),
-						},
-					},
-				},
-			},
-			// baseObject + stringObject + len(key) + stringObject + len(key)
-			expectedMem: SizeEmptyStruct + 22 + 3 + 22 + 5,
-			// baseObject + stringObject + (len(key) + overhead) + stringObject + (len(key) + overhead)
-			expectedNewMem: SizeEmptyStruct + 38 + (3 + SizeString) + 38 + (5 + SizeString),
-			errExpected:    nil,
-		},
-		{
-			name:           "mem is SizeEmptyStruct given a nil map object",
-			mu:             NewMemUsageContext(New(), 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
-			mo:             nil,
-			expectedMem:    SizeEmptyStruct,
-			expectedNewMem: SizeEmptyStruct,
-			errExpected:    nil,
-		},
+		// {
+		// 	name: "mem below threshold",
+		// 	mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+		// 	mo: &mapObject{
+		// 		m: &orderedMap{
+		// 			hashTable: map[uint64]*mapEntry{
+		// 				1: {
+		// 					key:   vm.ToValue("key"),
+		// 					value: vm.ToValue("value"),
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	// baseObject + (len(key) + overhead)  + (len(value) + overhead)
+		// 	expectedMem: SizeEmptyStruct + (3 + SizeString) + (5 + SizeString),
+		// 	// baseObject + (len(key) + overhead) + (len(value) + overhead)
+		// 	expectedNewMem: SizeEmptyStruct + (3 + SizeString) + (5 + SizeString),
+		// 	errExpected:    nil,
+		// },
+		// {
+		// 	name:           "mem is SizeEmptyStruct given a nil map object",
+		// 	mu:             NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+		// 	mo:             nil,
+		// 	expectedMem:    SizeEmptyStruct,
+		// 	expectedNewMem: SizeEmptyStruct,
+		// 	errExpected:    nil,
+		// },
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(New(), 88, 100, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
 						1: {
-							key:   New()._newString(newStringValue("key"), nil),
-							value: New()._newString(newStringValue("value"), nil),
+							key:   vm.ToValue("key"),
+							value: vm.ToValue("value"),
 						},
 						2: {
-							key:   New()._newString(newStringValue("key"), nil),
-							value: New()._newString(newStringValue("value"), nil),
+							key:   vm.ToValue("key"),
+							value: vm.ToValue("value"),
 						},
 						3: {
-							key:   New()._newString(newStringValue("key"), nil),
-							value: New()._newString(newStringValue("value"), nil),
+							key:   vm.ToValue("key"),
+							value: vm.ToValue("value"),
 						},
 						4: {
-							key:   New()._newString(newStringValue("key"), nil),
-							value: New()._newString(newStringValue("value"), nil),
+							key:   vm.ToValue("key"),
+							value: vm.ToValue("value"),
 						},
 					},
 				},
 			},
 			// baseObject
 			expectedMem: SizeEmptyStruct +
-				// stringObject + len(key) (we reach the limit after 2)
-				(22+3)*2 +
-				// stringObject + len(value) (we reach the limit after 2)
-				(22+5)*2,
+				// len(key) + overhead (we reach the limit after 3)
+				(3+SizeString)*3 +
+				// len(value) + overhead (we reach the limit after 3)
+				(5+SizeString)*3,
 			// baseObject
 			expectedNewMem: SizeEmptyStruct +
-				// stringObject + len(key) + overhead (we reach the limit after 2)
-				(38+(3+SizeString))*2 +
-				// stringObject + len(value) + overhead (we reach the limit after 2)
-				(38+(5+SizeString))*2,
+				// len(key) + overhead (we reach the limit after 3)
+				(3+SizeString)*3 +
+				// len(value) + overhead (we reach the limit after 3)
+				(5+SizeString)*3,
 			errExpected: nil,
 		},
 	}

--- a/date_test.go
+++ b/date_test.go
@@ -338,8 +338,8 @@ func TestDateMemUsage(t *testing.T) {
 			},
 			// msec value
 			expectedMem: SizeNumber +
-				// baseObject overhead + len("test") + value
-				SizeEmptyStruct + 4 + SizeInt,
+				// baseObject overhead + len("test") with string overhead + value
+				SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			// msec value
 			expectedNewMem: SizeNumber +
 				// baseObject overhead + len("test") with string overhead + value

--- a/object.go
+++ b/object.go
@@ -1941,7 +1941,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, ne
 	// memory usage across function executions
 	for i := 0; i < totalProps; i += sampleSize {
 		k := o.propNames[i]
-		memUsage += uint64(len(k))
+		memUsage += uint64(len(k)) + SizeString
 		newMemUsage += uint64(len(k)) + SizeString
 		v := o.values[k]
 		if v == nil {
@@ -1982,7 +1982,7 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsag
 	} else {
 		for _, k := range o.propNames {
 			v := o.values[k]
-			memUsage += uint64(len(k))
+			memUsage += uint64(len(k)) + SizeString
 			newMemUsage += uint64(len(k)) + SizeString
 
 			if v == nil {

--- a/object_dynamic_test.go
+++ b/object_dynamic_test.go
@@ -457,7 +457,7 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expectedMem:    SizeEmptyStruct + (4 + SizeInt),
+			expectedMem:    SizeEmptyStruct + (4 + SizeString + SizeInt),
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,
 		},

--- a/object_gomap.go
+++ b/object_gomap.go
@@ -181,7 +181,7 @@ func (o *objectGoMapSimple) MemUsage(ctx *MemUsageContext) (uint64, uint64, erro
 		return 0, 0, err
 	}
 	for key := range o.data {
-		mem += uint64(len(key))
+		mem += uint64(len(key)) + SizeString
 		newMem += uint64(len(key)) + SizeString
 		memValue, newMemValue, err := o._getStr(key).MemUsage(ctx)
 		mem += memValue

--- a/object_gomap_test.go
+++ b/object_gomap_test.go
@@ -365,8 +365,8 @@ func TestGoMapMemUsage(t *testing.T) {
 					"test1": valueInt(99),
 				},
 			},
-			// baseObject overhead + len("testN") + value
-			expectedMem: SizeEmptyStruct + (5+SizeInt)*2,
+			// baseObject overhead + len("testN") with string overhead + value
+			expectedMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*2,
 			// baseObject overhead + len("testN") with string overhead + value
 			expectedNewMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*2,
 			errExpected:    nil,
@@ -382,8 +382,8 @@ func TestGoMapMemUsage(t *testing.T) {
 					"test1": 99,
 				},
 			},
-			// baseObject overhead + len("testN") + value
-			expectedMem: SizeEmptyStruct + (5+SizeInt)*2,
+			// baseObject overhead + len("testN") with string overhead + value
+			expectedMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*2,
 			// baseObject overhead + len("testN") with string overhead + value
 			expectedNewMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*2,
 			errExpected:    nil,
@@ -398,8 +398,8 @@ func TestGoMapMemUsage(t *testing.T) {
 					"test": nil,
 				},
 			},
-			// overhead + len("test") + null
-			expectedMem: SizeEmptyStruct + 4 + SizeEmptyStruct,
+			// overhead + len("test") with string overhead + null
+			expectedMem: SizeEmptyStruct + (4 + SizeString) + SizeEmptyStruct,
 			// overhead + len("test") with string overhead + null
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + SizeEmptyStruct,
 			errExpected:    nil,
@@ -414,8 +414,8 @@ func TestGoMapMemUsage(t *testing.T) {
 					"test": nestedMap,
 				},
 			},
-			// overhead + len("test") + (Object prototype + values)
-			expectedMem: SizeEmptyStruct + 4 + nestedMapMemUsage,
+			// overhead + len("testN") with string overhead + (Object prototype with overhead + values with string overhead)
+			expectedMem: SizeEmptyStruct + (4 + SizeString) + nestedMapMemUsage,
 			// overhead + len("testN") with string overhead + (Object prototype with overhead + values with string overhead)
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + nestedMapNewMemUsage,
 			errExpected:    nil,
@@ -430,8 +430,8 @@ func TestGoMapMemUsage(t *testing.T) {
 					"test": &nestedMap,
 				},
 			},
-			// overhead + len("test") + nested overhead
-			expectedMem: SizeEmptyStruct + 4 + SizeEmptyStruct,
+			// overhead + len("testN") with string overhead + nested overhead
+			expectedMem: SizeEmptyStruct + (4 + SizeString) + SizeEmptyStruct,
 			// overhead + len("testN") with string overhead + nested overhead
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + SizeEmptyStruct,
 			errExpected:    nil,

--- a/object_goslice_test.go
+++ b/object_goslice_test.go
@@ -342,8 +342,8 @@ func TestGoSliceMemUsage(t *testing.T) {
 					},
 				},
 			},
-			// overhead + (value + len("length") + "length".value + prototype + ints)
-			expectedMem: SizeEmptyStruct + (SizeEmptyStruct + 6 + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
+			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
+			expectedMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
 			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
 			expectedNewMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
 			errExpected:    nil,
@@ -361,8 +361,8 @@ func TestGoSliceMemUsage(t *testing.T) {
 					},
 				},
 			},
-			// overhead + (value + len("length") + "length".value + prototype + ints)
-			expectedMem: SizeEmptyStruct + (SizeEmptyStruct + 6 + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
+			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
+			expectedMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
 			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
 			expectedNewMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
 			errExpected:    nil,

--- a/object_goslice_test.go
+++ b/object_goslice_test.go
@@ -299,6 +299,19 @@ func TestGoSliceMemUsage(t *testing.T) {
 			errExpected:    nil,
 		},
 		{
+			name: "should account for baseObject only given a nil data field",
+			val: &objectGoSlice{
+				baseObject: baseObject{
+					val: &Object{runtime: vm},
+				},
+			},
+			// overhead
+			expectedMem: SizeEmptyStruct,
+			// overhead
+			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
+		},
+		{
 			name: "should account for each value given a slice with go ints",
 			val: &objectGoSlice{
 				baseObject: baseObject{
@@ -342,8 +355,8 @@ func TestGoSliceMemUsage(t *testing.T) {
 					},
 				},
 			},
-			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
-			expectedMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
+			// default + default since we don't account for objectGoSlice in (*Object).MemUsage
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
 			expectedNewMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
 			errExpected:    nil,
@@ -361,8 +374,8 @@ func TestGoSliceMemUsage(t *testing.T) {
 					},
 				},
 			},
-			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
-			expectedMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
+			// default + default since we don't account for objectGoSlice in (*Object).MemUsage
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
 			// overhead + (value + len("length") with string overhead + "length".value + prototype + ints)
 			expectedNewMem: SizeEmptyStruct + (SizeEmptyStruct + (6 + SizeString) + SizeEmptyStruct + (SizeEmptyStruct + SizeEmptyStruct) + SizeNumber*2),
 			errExpected:    nil,
@@ -371,7 +384,7 @@ func TestGoSliceMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, nil))
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100000, 100, 100, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_test.go
+++ b/object_test.go
@@ -675,8 +675,8 @@ func TestBaseObjectMemUsage(t *testing.T) {
 			name:      "should account for each key value pair given a non-empty object",
 			threshold: 100,
 			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
-			// overhead + len("test") + value
-			expectedMem: SizeEmptyStruct + 4 + SizeInt,
+			// overhead + len("test") with string overhead + value
+			expectedMem: SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			// overhead + len("test") with string overhead + value
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			errExpected:    nil,
@@ -685,8 +685,8 @@ func TestBaseObjectMemUsage(t *testing.T) {
 			name:      "should account for each key value pair given a non-empty object with a nil value",
 			threshold: 100,
 			val:       &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": nil}},
-			// overhead + len("test")
-			expectedMem: SizeEmptyStruct + 4,
+			// overhead + len("test") with string overhead
+			expectedMem: SizeEmptyStruct + (4 + SizeString),
 			// overhead + len("test") with string overhead
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString),
 			errExpected:    nil,
@@ -708,8 +708,8 @@ func TestBaseObjectMemUsage(t *testing.T) {
 					"test3": valueInt(99),
 				},
 			},
-			// overhead + len("testN") + value
-			expectedMem: SizeEmptyStruct + (5+SizeInt)*4,
+			// overhead + len("testN") with string overhead + value
+			expectedMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*4,
 			// overhead + len("testN") with string overhead + value
 			expectedNewMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*4,
 			errExpected:    nil,
@@ -779,8 +779,8 @@ func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 		{
 			name: "should account for overehead and each key value pair given a primitive value object with non-empty object",
 			val:  &primitiveValueObject{baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}}},
-			// baseObject overhead + len("test") + value
-			expectedMem: SizeEmptyStruct + 4 + SizeInt,
+			// baseObject overhead + len("test") with string overhead + value
+			expectedMem: SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			// baseObject overhead + len("test") with string overhead + value
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString) + SizeInt,
 			errExpected:    nil,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -46,8 +46,8 @@ func TestProxyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// proxy overhead + baseObject overhead + target overhead + key/value pair
-			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,
@@ -70,8 +70,8 @@ func TestProxyMemUsage(t *testing.T) {
 					},
 				},
 			},
-			// proxy overhead + baseObject overhead + target overhead + key/value pair
-			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// proxy overhead + baseObject overhead + target overhead + key/value pair with string overhead
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,
@@ -126,8 +126,8 @@ func TestJSProxyHandlerMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// baseObject overhead + key/value pair
-			expectedMem: SizeEmptyStruct + (4 + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3001,8 +3001,8 @@ func TestRuntimeMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// baseObject overhead + key/value pair
-			expectedMem: SizeEmptyStruct + (4 + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,

--- a/string.go
+++ b/string.go
@@ -334,7 +334,7 @@ func (s *stringObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUs
 	}
 	ctx.VisitObj(s)
 
-	memUsage = uint64(s.length)
+	memUsage = uint64(s.length) + SizeString
 	newMemUsage = uint64(s.length) + SizeString
 	inc, newInc, err := s.baseObject.MemUsage(ctx)
 

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -333,7 +333,7 @@ func (s asciiString) ExportType() reflect.Type {
 }
 
 func (s asciiString) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	return uint64(s.length()), uint64(s.length()) + SizeString, err
+	return uint64(s.length()) + SizeString, uint64(s.length()) + SizeString, err
 }
 
 func (s asciiString) ToInt() int {

--- a/string_ascii_test.go
+++ b/string_ascii_test.go
@@ -15,14 +15,14 @@ func TestStringAsciiMemUsage(t *testing.T) {
 		{
 			name:           "should have a value of 0/SizeString given an empty string",
 			val:            asciiString(""),
-			expectedMem:    0,
+			expectedMem:    SizeString, // string overhead
 			expectedNewMem: SizeString, // string overhead
 			errExpected:    nil,
 		},
 		{
 			name:           "should have a value given the length of the string",
 			val:            asciiString("yo"),
-			expectedMem:    2,
+			expectedMem:    2 + SizeString, // length with string overhead
 			expectedNewMem: 2 + SizeString, // length with string overhead
 			errExpected:    nil,
 		},

--- a/string_imported.go
+++ b/string_imported.go
@@ -351,5 +351,5 @@ func (i *importedString) toTrimmedUTF8() string {
 }
 
 func (i *importedString) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	return uint64(len(i.String())), uint64(len(i.String())) + SizeString, err
+	return uint64(len(i.String())) + SizeString, uint64(len(i.String())) + SizeString, err
 }

--- a/string_imported_test.go
+++ b/string_imported_test.go
@@ -15,14 +15,14 @@ func TestStringImportedMemUsage(t *testing.T) {
 		{
 			name:           "should have a value of 0/SizeString given an empty string",
 			val:            &importedString{s: ""},
-			expectedMem:    0,
+			expectedMem:    SizeString, // string overhead
 			expectedNewMem: SizeString, // string overhead
 			errExpected:    nil,
 		},
 		{
 			name:           "should have a value given the length of the string",
 			val:            &importedString{s: "yo"},
-			expectedMem:    2,
+			expectedMem:    2 + SizeString, // length with string overhead
 			expectedNewMem: 2 + SizeString, // length with string overhead
 			errExpected:    nil,
 		},

--- a/string_test.go
+++ b/string_test.go
@@ -183,8 +183,8 @@ func TestStringObjectMemUsage(t *testing.T) {
 		{
 			"should account for base object and data given a non-empty stringObject",
 			&stringObject{value: newStringValue("yo"), length: 2},
-			// baseObject + len("yo")
-			SizeEmptyStruct + 2,
+			// baseObject + len("yo") and string overhead
+			SizeEmptyStruct + (2 + SizeString),
 			// baseObject + len("yo") and string overhead
 			SizeEmptyStruct + (2 + SizeString),
 		},

--- a/string_unicode.go
+++ b/string_unicode.go
@@ -560,7 +560,7 @@ func (s unicodeString) string() unistring.String {
 }
 
 func (s unicodeString) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	return uint64(len(s.String())), uint64(len(s.String())) + SizeString, err
+	return uint64(len(s.String())) + SizeString, uint64(len(s.String())) + SizeString, err
 }
 func (s unicodeString) ToInt() int {
 	return 0

--- a/string_unicode_test.go
+++ b/string_unicode_test.go
@@ -15,14 +15,14 @@ func TestStringUnicodeMemUsage(t *testing.T) {
 		{
 			name:           "should have a value of 0/SizeString given an empty string",
 			val:            unicodeString{' '},
-			expectedMem:    0,
+			expectedMem:    SizeString, // string overhead
 			expectedNewMem: SizeString, // string overhead
 			errExpected:    nil,
 		},
 		{
 			name:           "should have a value given the length of the string",
 			val:            unicodeString{' ', 'y', 'o'},
-			expectedMem:    2,
+			expectedMem:    2 + SizeString, // length with string overhead
 			expectedNewMem: 2 + SizeString, // length with string overhead
 			errExpected:    nil,
 		},

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -383,8 +383,8 @@ func TestArrayBufferObjectMemUsage(t *testing.T) {
 			val: &arrayBufferObject{
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
-			// baseObject overhead + key/value pair
-			expected: SizeEmptyStruct + (4 + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			expected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
 			newExpected: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
@@ -450,8 +450,8 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 			val: &typedArrayObject{
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
-			// typedArrayObject overhead + baseObject overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
+			expected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
 			newExpected: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
@@ -463,8 +463,8 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 					baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
 			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
@@ -485,8 +485,8 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair
-			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair with string overhead
+			expected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + defaultCtor overhead + key/value pair with string overhead
 			newExpected: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected: nil,
@@ -552,8 +552,8 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 			val: &dataViewObject{
 				baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
-			// typedArrayObject overhead + baseObject overhead + key/value pair
-			expectedMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// typedArrayObject overhead + baseObject overhead + key/value pair with string overhead
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,
@@ -565,8 +565,8 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 					baseObject: baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair
-			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeInt),
+			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// typedArrayObject overhead + nil baseObject overhead + arrayBufferObject overhead + key/value pair with string overhead
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,

--- a/value.go
+++ b/value.go
@@ -1182,6 +1182,12 @@ func (o *Object) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage ui
 		return SizeEmptyStruct, SizeEmptyStruct, nil
 	case *objectGoSliceReflect:
 		return SizeEmptyStruct, SizeEmptyStruct, nil
+	case *objectGoMapSimple:
+		_, newMemUsage, err := x.MemUsage(ctx)
+		return SizeEmptyStruct, newMemUsage, err
+	case *objectGoSlice:
+		_, newMemUsage, err := x.MemUsage(ctx)
+		return SizeEmptyStruct, newMemUsage, err
 	default:
 		r, ok := x.(MemUsageReporter)
 		if !ok {

--- a/value.go
+++ b/value.go
@@ -1474,7 +1474,7 @@ func (o valueUnresolved) hash(*maphash.Hash) uint64 {
 }
 
 func (o valueUnresolved) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage uint64, err error) {
-	return uint64(len(o.ref)), uint64(len(o.ref)) + SizeString, nil
+	return uint64(len(o.ref)) + SizeString, uint64(len(o.ref)) + SizeString, nil
 }
 
 func (o valueUnresolved) ToInt() int {

--- a/value_test.go
+++ b/value_test.go
@@ -96,14 +96,14 @@ func TestValueMemUsage(t *testing.T) {
 		{
 			name:           "should account for ref given a valueUnresolved",
 			val:            valueUnresolved{ref: "test"},
-			expectedMem:    4,
+			expectedMem:    4 + SizeString,
 			expectedNewMem: 4 + SizeString,
 			errExpected:    nil,
 		},
 		{
 			name:           "should account for desc given a Symbol",
 			val:            &Symbol{desc: newStringValue("test")},
-			expectedMem:    4,
+			expectedMem:    4 + SizeString,
 			expectedNewMem: 4 + SizeString,
 			errExpected:    nil,
 		},
@@ -164,7 +164,7 @@ func TestValuePropertyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expectedMem:    SizeEmptyStruct + SizeEmptyStruct + 4,
+			expectedMem:    SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
 			errExpected:    nil,
 		},
@@ -175,7 +175,7 @@ func TestValuePropertyMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			expectedMem:    SizeEmptyStruct + SizeEmptyStruct + 4,
+			expectedMem:    SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
 			expectedNewMem: SizeEmptyStruct + SizeEmptyStruct + (4 + SizeString),
 			errExpected:    nil,
 		},
@@ -269,8 +269,8 @@ func TestObjectMemUsage(t *testing.T) {
 			val: &Object{
 				self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 			},
-			// baseObject overhead + value
-			expectedMem: SizeEmptyStruct + (4 + SizeInt),
+			// baseObject overhead + value with string overhead
+			expectedMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// baseObject overhead + value with string overhead
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,

--- a/value_test.go
+++ b/value_test.go
@@ -201,6 +201,7 @@ func TestValuePropertyMemUsage(t *testing.T) {
 }
 
 func TestObjectMemUsage(t *testing.T) {
+	vm := New()
 	tests := []struct {
 		name           string
 		val            *Object
@@ -244,17 +245,47 @@ func TestObjectMemUsage(t *testing.T) {
 			errExpected:    nil,
 		},
 		{
-			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapSimple",
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoMapSimple empty",
 			val:            &Object{self: &objectGoMapSimple{}},
 			expectedMem:    SizeEmptyStruct,
 			expectedNewMem: SizeEmptyStruct,
 			errExpected:    nil,
 		},
 		{
-			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoSlice",
+			name: "should have different values given an Object with self of type objectGoMapSimple non empty",
+			val: &Object{self: &objectGoMapSimple{
+				baseObject: baseObject{
+					val: &Object{runtime: vm},
+				},
+				data: map[string]interface{}{
+					"test0": valueInt(99),
+					"test1": valueInt(99),
+				},
+			}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct + ((5+SizeString)+SizeInt)*2,
+			errExpected:    nil,
+		},
+		{
+			name:           "should have a value of SizeEmptyStruct given an Object with self of type objectGoSlice empty",
 			val:            &Object{self: &objectGoSlice{}},
 			expectedMem:    SizeEmptyStruct,
 			expectedNewMem: SizeEmptyStruct,
+			errExpected:    nil,
+		},
+		{
+			name: "should have different values given an Object with self of type objectGoSlice non empty",
+			val: &Object{self: &objectGoSlice{
+				baseObject: baseObject{
+					val: &Object{runtime: vm},
+				},
+				data: &[]interface{}{
+					valueInt(99),
+					valueInt(99),
+				},
+			}},
+			expectedMem:    SizeEmptyStruct,
+			expectedNewMem: SizeEmptyStruct + SizeInt*2,
 			errExpected:    nil,
 		},
 		{

--- a/vm_test.go
+++ b/vm_test.go
@@ -487,8 +487,8 @@ func TestStashMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
-			// baseObject overhead + obj value
-			expectedMem: SizeEmptyStruct + (4 + SizeInt),
+			// baseObject overhead + obj value with string overhead
+			expectedMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// baseObject overhead + obj value with string overhead
 			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			errExpected:    nil,


### PR DESCRIPTION
Doing this so that the memory usage is now correct and the new memory usage has the only difference of accounting for objectGoSlice and objectGoMapSimple. This will help us differentiate the contribution and diff of these new memory changes.

I expect moving forward for the process to be similar to this, once the memory changes are in production and we are good, we can promote them in goja as well so that any new memory change can be tracked independently.

Estimates and early exit for objectGoSlice and objectGoMapSimple are part of a follow-up ticket.