### PR TITLE
BAAS-24694: Safely handle empty fromEntries values

### DIFF
--- a/builtin_object.go
+++ b/builtin_object.go
@@ -584,7 +584,7 @@ func (r *Runtime) object_fromEntries(call FunctionCall) Value {
 		itemObj := r.toObject(nextValue)
 		k := itemObj.self.getIdx(i0, nil)
 		v := itemObj.self.getIdx(i1, nil)
-		key := toPropertyKey(k)
+		key := toPropertyKey(nilSafe(k))
 
 		createDataPropertyOrThrow(result, key, v)
 	})

--- a/builtin_object_test.go
+++ b/builtin_object_test.go
@@ -274,6 +274,12 @@ func TestObject_fromEntries(t *testing.T) {
  					 [ o.a, o.b, o.c ]
  				 `, "1,true,sea",
 		},
+		{
+			`
+ 					 var o = Object.fromEntries([['a', 1], [], ['b', true]]);
+ 					 [ o.a, o.b ]
+ 				 `, "1,true",
+		},
 	} {
 		actual, err := vm.RunString(tt.js)
 		if err != nil {

--- a/builtin_object_test.go
+++ b/builtin_object_test.go
@@ -276,9 +276,9 @@ func TestObject_fromEntries(t *testing.T) {
 		},
 		{
 			`
- 					 var o = Object.fromEntries([['a', 1], [], ['b', true]]);
- 					 [ o.a, o.b ]
- 				 `, "1,true",
+ 					 var o = Object.fromEntries([['a', 1], [, 'empty'], ['b', true]]);
+ 					 [ o.a, o[undefined], o.b ]
+ 				 `, "1,empty,true",
 		},
 	} {
 		actual, err := vm.RunString(tt.js)


### PR DESCRIPTION
Currently, `Object.fromEntries` calls will panic for empty entries due to the fact that `toPropertyKey` blindly calls `key.toString()` without checking if `key` is nil:

```javascript
Object.fromEntries([
    ['a', 123], 
    ['b', 456], 
]) // => { a: 123, b: 456 }

Object.fromEntries([
    ['a', 123], // safe
    [], // panic!
    ['b', 456], 
]) // should be => { a: 123, undefined: undefined, b: 456 }
```

Goja provides an existing `nilSafe` method that returns `_undefined` for `nil` values, so I've gone ahead and used that. 

~Planning on submitting a PR upstream to goja to fix this, but figured it would be faster to just handle this here first.~

EDIT: nevermind, I didn't realize that we were the ones that added the `fromEntries` tests, `nilSafe` function, etc. 🙄 