### PR TITLE
BAAS-26274: Increase int and int64 cache size to 16384

### DIFF
--- a/value.go
+++ b/value.go
@@ -57,8 +57,8 @@ var (
 	reflectTypeError  = reflect.TypeOf((*error)(nil)).Elem()
 )
 
-var intCache [256]Value
-var int64Cache [256]Value
+var intCache [16384]Value
+var int64Cache [16384]Value
 
 func FalseValue() Value {
 	return valueFalse
@@ -1710,11 +1710,11 @@ func typeErrorResult(throw bool, args ...interface{}) {
 }
 
 func init() {
-	for i := 0; i < 256; i++ {
-		intCache[i] = valueInt(i - 128)
+	for i := 0; i < 16384; i++ {
+		intCache[i] = valueInt(i - 8192)
 	}
-	for i := 0; i < 256; i++ {
-		int64Cache[i] = valueInt64(i - 128)
+	for i := 0; i < 16384; i++ {
+		int64Cache[i] = valueInt64(i - 8192)
 	}
 	_positiveZero = intToValue(0)
 }

--- a/value.go
+++ b/value.go
@@ -57,8 +57,10 @@ var (
 	reflectTypeError  = reflect.TypeOf((*error)(nil)).Elem()
 )
 
-var intCache [16384]Value
-var int64Cache [16384]Value
+const intCacheSize = 16384
+
+var intCache [intCacheSize]Value
+var int64Cache [256]Value
 
 func FalseValue() Value {
 	return valueFalse
@@ -1710,11 +1712,11 @@ func typeErrorResult(throw bool, args ...interface{}) {
 }
 
 func init() {
-	for i := 0; i < 16384; i++ {
-		intCache[i] = valueInt(i - 8192)
+	for i := 0; i < intCacheSize; i++ {
+		intCache[i] = valueInt(i - 128)
 	}
-	for i := 0; i < 16384; i++ {
-		int64Cache[i] = valueInt64(i - 8192)
+	for i := 0; i < 256; i++ {
+		int64Cache[i] = valueInt64(i - 128)
 	}
 	_positiveZero = intToValue(0)
 }

--- a/vm.go
+++ b/vm.go
@@ -327,8 +327,8 @@ func (vm *vm) setFuncName(s unistring.String) {
 
 func intToValue(i int64) Value {
 	if i >= -maxInt && i <= maxInt {
-		if i >= -128 && i <= 127 {
-			return intCache[i+128]
+		if i >= -8192 && i <= 8191 {
+			return intCache[i+8192]
 		}
 		return valueInt(i)
 	}
@@ -336,8 +336,8 @@ func intToValue(i int64) Value {
 }
 
 func int64ToValue(i int64) Value {
-	if i >= -128 && i <= 127 {
-		return int64Cache[i+128]
+	if i >= -8192 && i <= 8191 {
+		return int64Cache[i+8192]
 	}
 	return valueInt64(i)
 }

--- a/vm.go
+++ b/vm.go
@@ -327,8 +327,8 @@ func (vm *vm) setFuncName(s unistring.String) {
 
 func intToValue(i int64) Value {
 	if i >= -maxInt && i <= maxInt {
-		if i >= -8192 && i <= 8191 {
-			return intCache[i+8192]
+		if i >= -128 && i <= (intCacheSize-129) {
+			return intCache[i+128]
 		}
 		return valueInt(i)
 	}
@@ -336,8 +336,8 @@ func intToValue(i int64) Value {
 }
 
 func int64ToValue(i int64) Value {
-	if i >= -8192 && i <= 8191 {
-		return int64Cache[i+8192]
+	if i >= -128 && i <= 127 {
+		return int64Cache[i+128]
 	}
 	return valueInt64(i)
 }


### PR DESCRIPTION
Increased cache size from 256 (2^8) to 16384 (2^14)

New size calculations:

Interface size = 16b
int size            = 32b

Each Value in intCache should be 48b

new intCache memory footprint: 16384 * 48b = 786,432b = 768kb = 0.75mb