### PR TITLE
BAAS-27268: add early exit in mem usage where missing

### DIFF
--- a/memory_test.go
+++ b/memory_test.go
@@ -780,22 +780,6 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			expectedNewSizeDiff: SizeEmptyStruct + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
-			desc: "object under threshold but over limit should exit early",
-			script: `y = {}
-			let i = 0;
-			checkMem();
-			for (i=0;i<10;i++) {
-				y["i"+i] = i
-			}
-			checkMem()`,
-			threshold: 100,
-			memLimit:  100,
-			// object overhead
-			expectedSizeDiff: SizeEmptyStruct,
-			// object overhead
-			expectedNewSizeDiff: SizeEmptyStruct,
-		},
-		{
 			desc: "object over threshold",
 			script: `y = {}
 			let i = 0;

--- a/memory_test.go
+++ b/memory_test.go
@@ -655,22 +655,6 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				+1,
 		},
 		{
-			desc: "array under threshold but over limit",
-			script: `y = []
-			y.push([]);
-			let i = 0;
-			checkMem();
-			for(i=0;i<10;i++){
-				y[0].push(i);
-			};
-			checkMem()`,
-			threshold: 200,
-			memLimit:  100,
-			// Array overhead, size of property values, only 3 values before we hit the mem limit
-			expectedSizeDiff:    SizeEmptyStruct + (3 * SizeNumber),
-			expectedNewSizeDiff: SizeEmptyStruct + (3 * SizeNumber),
-		},
-		{
 			desc: "mixed array over threshold",
 			script: `y = []
 			y.push([]);
@@ -796,7 +780,7 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			expectedNewSizeDiff: SizeEmptyStruct + 10*(2+SizeString) + 10*SizeNumber,
 		},
 		{
-			desc: "object under threshold but over limit",
+			desc: "object under threshold but over limit should exit early",
 			script: `y = {}
 			let i = 0;
 			checkMem();
@@ -805,11 +789,11 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			}
 			checkMem()`,
 			threshold: 100,
-			memLimit:  40,
-			// object overhead + len("i0") + value i
-			expectedSizeDiff: SizeEmptyStruct + 10*(2+SizeString) + 10*SizeNumber,
-			// object overhead + len("i0") + value i
-			expectedNewSizeDiff: SizeEmptyStruct + 10*(2+SizeString) + 10*SizeNumber,
+			memLimit:  0,
+			// object overhead
+			expectedSizeDiff: SizeEmptyStruct,
+			// object overhead
+			expectedNewSizeDiff: SizeEmptyStruct,
 		},
 		{
 			desc: "object over threshold",

--- a/memory_test.go
+++ b/memory_test.go
@@ -789,7 +789,7 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 			}
 			checkMem()`,
 			threshold: 100,
-			memLimit:  0,
+			memLimit:  100,
 			// object overhead
 			expectedSizeDiff: SizeEmptyStruct,
 			// object overhead

--- a/object.go
+++ b/object.go
@@ -1975,6 +1975,9 @@ func (o *baseObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsag
 			if err != nil {
 				return memUsage, newMemUsage, err
 			}
+			if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+				return memUsage, newMemUsage, nil
+			}
 		}
 	}
 

--- a/object_gomap.go
+++ b/object_gomap.go
@@ -171,6 +171,9 @@ func (o *objectGoMapSimple) MemUsage(ctx *MemUsageContext) (uint64, uint64, erro
 		if err != nil {
 			return mem, newMem, err
 		}
+		if exceeded := ctx.MemUsageLimitExceeded(mem); exceeded {
+			return mem, newMem, nil
+		}
 	}
 	return mem, newMem, nil
 }

--- a/object_goslice.go
+++ b/object_goslice.go
@@ -365,6 +365,9 @@ func (o *objectGoSlice) MemUsage(ctx *MemUsageContext) (uint64, uint64, error) {
 		if err != nil {
 			return mem, newMem, err
 		}
+		if exceeded := ctx.MemUsageLimitExceeded(mem); exceeded {
+			return mem, newMem, nil
+		}
 	}
 	return mem, newMem, nil
 }

--- a/runtime.go
+++ b/runtime.go
@@ -515,6 +515,9 @@ func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage u
 			if err != nil {
 				return memUsage, newMemUsage, err
 			}
+			if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+				return memUsage, newMemUsage, nil
+			}
 		}
 	}
 

--- a/runtime.go
+++ b/runtime.go
@@ -501,6 +501,9 @@ func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage u
 		if err != nil {
 			return memUsage, newMemUsage, err
 		}
+		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+			return memUsage, newMemUsage, nil
+		}
 	}
 
 	if r.vm == nil {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3087,14 +3087,34 @@ func TestRuntimeMemUsage(t *testing.T) {
 			name: "should account for globalObject given a runtime with non-empty globalObject",
 			val: &Runtime{
 				globalObject: &Object{
-					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
+					self: &baseObject{
+						propNames: []unistring.String{"test0", "test1", "test2"},
+						values:    map[unistring.String]Value{"test0": valueInt(99), "test1": valueInt(99), "test2": valueInt(99)},
+					},
 				},
 			},
 			memLimit: 100,
 			// baseObject overhead + key/value pair with string overhead
-			expectedMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			expectedMem: SizeEmptyStruct + (5+SizeString+SizeInt)*3,
 			// baseObject overhead + key/value pair with string overhead
-			expectedNewMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
+			expectedNewMem: SizeEmptyStruct + (5+SizeString+SizeInt)*3,
+			errExpected:    nil,
+		},
+		{
+			name: "should exit early given a runtime with non-empty globalObject exceeding the memory limit",
+			val: &Runtime{
+				globalObject: &Object{
+					self: &baseObject{
+						propNames: []unistring.String{"test0", "test1", "test2"},
+						values:    map[unistring.String]Value{"test0": valueInt(99), "test1": valueInt(99), "test2": valueInt(99)},
+					},
+				},
+			},
+			memLimit: 0,
+			// baseObject overhead + key/value pair with string overhead
+			expectedMem: SizeEmptyStruct + (5 + SizeString + SizeInt),
+			// baseObject overhead + key/value pair with string overhead
+			expectedNewMem: SizeEmptyStruct + (5 + SizeString + SizeInt),
 			errExpected:    nil,
 		},
 		{

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3070,6 +3070,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 	tests := []struct {
 		name           string
 		val            *Runtime
+		memLimit       uint64
 		expectedMem    uint64
 		expectedNewMem uint64
 		errExpected    error
@@ -3077,6 +3078,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 		{
 			name:           "should have a value of SizeEmptyStruct given a nil runtime",
 			val:            nil,
+			memLimit:       100,
 			expectedMem:    SizeEmptyStruct,
 			expectedNewMem: SizeEmptyStruct,
 			errExpected:    nil,
@@ -3088,6 +3090,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 					self: &baseObject{propNames: []unistring.String{"test"}, values: map[unistring.String]Value{"test": valueInt(99)}},
 				},
 			},
+			memLimit: 100,
 			// baseObject overhead + key/value pair with string overhead
 			expectedMem: SizeEmptyStruct + (4 + SizeString + SizeInt),
 			// baseObject overhead + key/value pair with string overhead
@@ -3099,6 +3102,19 @@ func TestRuntimeMemUsage(t *testing.T) {
 			val: &Runtime{
 				vm: &vm{callStack: []vmContext{{newTarget: valueInt(99)}}},
 			},
+			memLimit: 100,
+			// vmContext overhead + value
+			expectedMem: SizeEmptyStruct + SizeInt,
+			// vmContext overhead + value
+			expectedNewMem: SizeEmptyStruct + SizeInt,
+			errExpected:    nil,
+		},
+		{
+			name: "should exit early given a callStack exceeding the memory limit",
+			val: &Runtime{
+				vm: &vm{callStack: []vmContext{{newTarget: valueInt(99)}, {newTarget: valueInt(99)}, {newTarget: valueInt(99)}}},
+			},
+			memLimit: 0,
 			// vmContext overhead + value
 			expectedMem: SizeEmptyStruct + SizeInt,
 			// vmContext overhead + value
@@ -3110,6 +3126,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 			val: &Runtime{
 				vm: &vm{stash: &stash{values: []Value{valueInt(99)}}},
 			},
+			memLimit: 100,
 			// stash value
 			expectedMem: SizeInt,
 			// stash value
@@ -3121,6 +3138,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 			val: &Runtime{
 				vm: &vm{stack: []Value{valueInt(99)}},
 			},
+			memLimit: 100,
 			// stack value
 			expectedMem: SizeInt,
 			// stack value
@@ -3131,7 +3149,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, newTotal, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/vm.go
+++ b/vm.go
@@ -5579,6 +5579,9 @@ func (s valueStack) MemUsage(ctx *MemUsageContext) (memUsage uint64, newMemUsage
 		if err != nil {
 			return memUsage, newMemUsage, err
 		}
+		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+			return memUsage, newMemUsage, nil
+		}
 	}
 
 	return memUsage, newMemUsage, nil


### PR DESCRIPTION
I deleted two tests that were redundant and were cumbersome to figure out the proper mem limit number. Even for future changes I think it would have been an unnecessary complication.