### PR TITLE
BAAS-28579: Avoid switching valueInt64 to valueInt when incrementing value

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -365,20 +365,20 @@ func floatToValue(f float64) (result Value) {
 	return valueFloat(f)
 }
 
-func assertInt64(v Value) (int64, bool) {
+func assertInt64(v Value) (int64, bool, bool) {
 	num := v.ToNumber()
 	if i, ok := num.(valueInt); ok {
-		return int64(i), true
+		return int64(i), true, false
 	}
 	if _, ok := num.(valueInt64); ok {
-		return v.ToInt64(), true
+		return v.ToInt64(), true, true
 	}
 	if f, ok := num.(valueFloat); ok {
 		if i, ok := floatToInt(float64(f)); ok {
-			return i, true
+			return i, true, false
 		}
 	}
-	return 0, false
+	return 0, false, false
 }
 
 func (s *valueStack) expand(idx int) {
@@ -1282,8 +1282,8 @@ func (_mul) exec(vm *vm) {
 
 	var result Value
 
-	if left, ok := assertInt64(left); ok {
-		if right, ok := assertInt64(right); ok {
+	if left, ok, _ := assertInt64(left); ok {
+		if right, ok, _ := assertInt64(right); ok {
 			if left == 0 && right == -1 || left == -1 && right == 0 {
 				result = _negativeZero
 				goto end
@@ -1385,8 +1385,8 @@ func (_mod) exec(vm *vm) {
 
 	var result Value
 
-	if leftInt, ok := assertInt64(left); ok {
-		if rightInt, ok := assertInt64(right); ok {
+	if leftInt, ok, _ := assertInt64(left); ok {
+		if rightInt, ok, _ := assertInt64(right); ok {
 			if rightInt == 0 {
 				result = _NaN
 				goto end
@@ -1417,7 +1417,7 @@ func (_neg) exec(vm *vm) {
 
 	var result Value
 
-	if i, ok := assertInt64(operand); ok {
+	if i, ok, _ := assertInt64(operand); ok {
 		if i == 0 {
 			result = _negativeZero
 		} else {
@@ -1451,8 +1451,12 @@ var inc _inc
 func (_inc) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 
-	if i, ok := assertInt64(v); ok {
-		v = intToValue(i + 1)
+	if i, ok, isInt64 := assertInt64(v); ok {
+		if isInt64 {
+			v = int64ToValue(i + 1)
+		} else {
+			v = intToValue(i + 1)
+		}
 		goto end
 	}
 
@@ -1470,8 +1474,12 @@ var dec _dec
 func (_dec) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 
-	if i, ok := assertInt64(v); ok {
-		v = intToValue(i - 1)
+	if i, ok, isInt64 := assertInt64(v); ok {
+		if isInt64 {
+			v = int64ToValue(i - 1)
+		} else {
+			v = intToValue(i - 1)
+		}
 		goto end
 	}
 

--- a/vm.go
+++ b/vm.go
@@ -1282,8 +1282,8 @@ func (_mul) exec(vm *vm) {
 
 	var result Value
 
-	if left, ok, _ := assertInt64(left); ok {
-		if right, ok, _ := assertInt64(right); ok {
+	if left, ok, leftIsInt64 := assertInt64(left); ok {
+		if right, ok, rightIsInt64 := assertInt64(right); ok {
 			if left == 0 && right == -1 || left == -1 && right == 0 {
 				result = _negativeZero
 				goto end
@@ -1291,7 +1291,11 @@ func (_mul) exec(vm *vm) {
 			res := left * right
 			// check for overflow
 			if left == 0 || right == 0 || res/left == right {
-				result = intToValue(res)
+				if leftIsInt64 || rightIsInt64 {
+					result = int64ToValue(res)
+				} else {
+					result = intToValue(res)
+				}
 				goto end
 			}
 
@@ -1385,8 +1389,8 @@ func (_mod) exec(vm *vm) {
 
 	var result Value
 
-	if leftInt, ok, _ := assertInt64(left); ok {
-		if rightInt, ok, _ := assertInt64(right); ok {
+	if leftInt, ok, leftIsInt64 := assertInt64(left); ok {
+		if rightInt, ok, rightIsInt64 := assertInt64(right); ok {
 			if rightInt == 0 {
 				result = _NaN
 				goto end
@@ -1394,6 +1398,8 @@ func (_mod) exec(vm *vm) {
 			r := leftInt % rightInt
 			if r == 0 && leftInt < 0 {
 				result = _negativeZero
+			} else if leftIsInt64 || rightIsInt64 {
+				result = int64ToValue(leftInt % rightInt)
 			} else {
 				result = intToValue(leftInt % rightInt)
 			}
@@ -1417,9 +1423,11 @@ func (_neg) exec(vm *vm) {
 
 	var result Value
 
-	if i, ok, _ := assertInt64(operand); ok {
+	if i, ok, isInt64 := assertInt64(operand); ok {
 		if i == 0 {
 			result = _negativeZero
+		} else if isInt64 {
+			result = valueInt64(-i)
 		} else {
 			result = valueInt(-i)
 		}

--- a/vm.go
+++ b/vm.go
@@ -1454,12 +1454,20 @@ func (_inc) exec(vm *vm) {
 	switch i := v.(type) {
 	case valueInt:
 		v = i + 1
+		goto end
 	case valueInt64:
 		v = i + 1
-	default:
-		v = valueFloat(v.ToFloat() + 1)
+		goto end
+	case valueFloat:
+		if f, ok := floatToInt(float64(i)); ok {
+			v = intToValue(f + 1)
+			goto end
+		}
 	}
 
+	v = valueFloat(v.ToFloat() + 1)
+
+end:
 	vm.stack[vm.sp-1] = v
 	vm.pc++
 }
@@ -1474,12 +1482,20 @@ func (_dec) exec(vm *vm) {
 	switch i := v.(type) {
 	case valueInt:
 		v = i - 1
+		goto end
 	case valueInt64:
 		v = i - 1
-	default:
-		v = valueFloat(v.ToFloat() - 1)
+		goto end
+	case valueFloat:
+		if f, ok := floatToInt(float64(i)); ok {
+			v = intToValue(f - 1)
+			goto end
+		}
 	}
 
+	v = valueFloat(v.ToFloat() - 1)
+
+end:
 	vm.stack[vm.sp-1] = v
 	vm.pc++
 }

--- a/vm.go
+++ b/vm.go
@@ -1451,14 +1451,15 @@ var inc _inc
 func (_inc) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 
-	if i, ok := assertInt64(v); ok {
-		v = intToValue(i + 1)
-		goto end
+	switch i := v.(type) {
+	case valueInt:
+		v = i + 1
+	case valueInt64:
+		v = i + 1
+	case valueFloat:
+		v = i + 1
 	}
 
-	v = valueFloat(v.ToFloat() + 1)
-
-end:
 	vm.stack[vm.sp-1] = v
 	vm.pc++
 }
@@ -1470,14 +1471,15 @@ var dec _dec
 func (_dec) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 
-	if i, ok := assertInt64(v); ok {
-		v = intToValue(i - 1)
-		goto end
+	switch i := v.(type) {
+	case valueInt:
+		v = i - 1
+	case valueInt64:
+		v = i - 1
+	case valueFloat:
+		v = i - 1
 	}
 
-	v = valueFloat(v.ToFloat() - 1)
-
-end:
 	vm.stack[vm.sp-1] = v
 	vm.pc++
 }

--- a/vm.go
+++ b/vm.go
@@ -365,20 +365,20 @@ func floatToValue(f float64) (result Value) {
 	return valueFloat(f)
 }
 
-func assertInt64(v Value) (int64, bool, bool) {
+func assertInt64(v Value) (int64, bool) {
 	num := v.ToNumber()
 	if i, ok := num.(valueInt); ok {
-		return int64(i), true, false
+		return int64(i), true
 	}
 	if _, ok := num.(valueInt64); ok {
-		return v.ToInt64(), true, true
+		return v.ToInt64(), true
 	}
 	if f, ok := num.(valueFloat); ok {
 		if i, ok := floatToInt(float64(f)); ok {
-			return i, true, false
+			return i, true
 		}
 	}
-	return 0, false, false
+	return 0, false
 }
 
 func (s *valueStack) expand(idx int) {
@@ -1282,8 +1282,8 @@ func (_mul) exec(vm *vm) {
 
 	var result Value
 
-	if left, ok, leftIsInt64 := assertInt64(left); ok {
-		if right, ok, rightIsInt64 := assertInt64(right); ok {
+	if left, ok := assertInt64(left); ok {
+		if right, ok := assertInt64(right); ok {
 			if left == 0 && right == -1 || left == -1 && right == 0 {
 				result = _negativeZero
 				goto end
@@ -1291,11 +1291,7 @@ func (_mul) exec(vm *vm) {
 			res := left * right
 			// check for overflow
 			if left == 0 || right == 0 || res/left == right {
-				if leftIsInt64 || rightIsInt64 {
-					result = int64ToValue(res)
-				} else {
-					result = intToValue(res)
-				}
+				result = intToValue(res)
 				goto end
 			}
 
@@ -1389,8 +1385,8 @@ func (_mod) exec(vm *vm) {
 
 	var result Value
 
-	if leftInt, ok, leftIsInt64 := assertInt64(left); ok {
-		if rightInt, ok, rightIsInt64 := assertInt64(right); ok {
+	if leftInt, ok := assertInt64(left); ok {
+		if rightInt, ok := assertInt64(right); ok {
 			if rightInt == 0 {
 				result = _NaN
 				goto end
@@ -1398,8 +1394,6 @@ func (_mod) exec(vm *vm) {
 			r := leftInt % rightInt
 			if r == 0 && leftInt < 0 {
 				result = _negativeZero
-			} else if leftIsInt64 || rightIsInt64 {
-				result = int64ToValue(leftInt % rightInt)
 			} else {
 				result = intToValue(leftInt % rightInt)
 			}
@@ -1423,11 +1417,9 @@ func (_neg) exec(vm *vm) {
 
 	var result Value
 
-	if i, ok, isInt64 := assertInt64(operand); ok {
+	if i, ok := assertInt64(operand); ok {
 		if i == 0 {
 			result = _negativeZero
-		} else if isInt64 {
-			result = valueInt64(-i)
 		} else {
 			result = valueInt(-i)
 		}
@@ -1459,12 +1451,8 @@ var inc _inc
 func (_inc) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 
-	if i, ok, isInt64 := assertInt64(v); ok {
-		if isInt64 {
-			v = int64ToValue(i + 1)
-		} else {
-			v = intToValue(i + 1)
-		}
+	if i, ok := assertInt64(v); ok {
+		v = intToValue(i + 1)
 		goto end
 	}
 
@@ -1482,12 +1470,8 @@ var dec _dec
 func (_dec) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 
-	if i, ok, isInt64 := assertInt64(v); ok {
-		if isInt64 {
-			v = int64ToValue(i - 1)
-		} else {
-			v = intToValue(i - 1)
-		}
+	if i, ok := assertInt64(v); ok {
+		v = intToValue(i - 1)
 		goto end
 	}
 

--- a/vm.go
+++ b/vm.go
@@ -1456,8 +1456,8 @@ func (_inc) exec(vm *vm) {
 		v = i + 1
 	case valueInt64:
 		v = i + 1
-	case valueFloat:
-		v = i + 1
+	default:
+		v = valueFloat(v.ToFloat() + 1)
 	}
 
 	vm.stack[vm.sp-1] = v
@@ -1476,8 +1476,8 @@ func (_dec) exec(vm *vm) {
 		v = i - 1
 	case valueInt64:
 		v = i - 1
-	case valueFloat:
-		v = i - 1
+	default:
+		v = valueFloat(v.ToFloat() - 1)
 	}
 
 	vm.stack[vm.sp-1] = v


### PR DESCRIPTION
I found this while troubleshooting why our realm branch was slower than the master branch.

Turns out our cmp [function](https://github.com/dop251/goja/blob/c0ed032e8e1f77668546c67ec9aacbde8149caeb/vm.go#L4218) is less efficient because when we increment `i` in our for loops we are switching its type from int64 to int in the [_inc.exec](https://github.com/dop251/goja/blob/c0ed032e8e1f77668546c67ec9aacbde8149caeb/vm.go#L1475) function when we make a call to intToValue. This leads to a mismatch in type between the incrementing value and the target so the corresponding [compare logic](https://github.com/mongodb-forks/goja/blob/b03d5eb6e1a770e6bca8ef1818a3958a5de42462/vm.go#L4218-L4236) is not as efficient. I found this when comparing pprofs.


Benchmark results:
master
```
goja (master)$ go test -ldflags="-r /Users/calvin.nix/dev/baas/etc/dylib/lib" --bench="BenchmarkEmptyLoop" --run="BenchmarkEmptyLoop" -benchtime 1s
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10             246348              4844 ns/op
PASS
ok      github.com/dop251/goja  2.483s
```

realm (before these changes)
```
goja (realm)$ go test -ldflags="-r /Users/calvin.nix/dev/baas/etc/dylib/lib" --bench="BenchmarkEmptyLoop" --run="BenchmarkEmptyLoop" -benchtime 1s
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10             211112              5612 ns/op
PASS
ok      github.com/dop251/goja  2.704s
```

realm (now)
```
goja (realm)$ go test -ldflags="-r /Users/calvin.nix/dev/baas/etc/dylib/lib" --bench="BenchmarkEmptyLoop" --run="BenchmarkEmptyLoop" -benchtime 1s
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkEmptyLoop-10             227860              5202 ns/op
PASS
ok      github.com/dop251/goja  2.481s
```
Note that the remaining loop perf difference between realm and master has to do with our tick counter and limiterTicksLeft check.


The [benchmark results in baas](https://spruce.mongodb.com/task/baas_mdb_latest_rapid_release_benchmark_vm_patch_f541693b016eda2f6b07136205e0fb4829c8aa94_65c6b0b2c9ec448b0eb28c8d_24_02_09_23_09_49/logs?execution=0) were pretty much in line with expectations. There is roughly a ~5-10% loop performance benefit highlighted by these benchmark tests.

```
...
[2024/02/09 18:41:55.383] VMRateLimiter/with_an_infinite_rate_and_default_burst/loop-16                        5.89s ± 0%     5.53s ± 0%   -6.18%
...
[2024/02/09 18:41:55.384] VMRateLimiter/with_an_infinite_rate_and_default_burst/pbkdf2-16                      523ms ± 0%     474ms ± 0%   -9.41%
...
```