### PR TITLE
BAAS-22177: add mem usage estimate for sparse arrays

### DIFF
--- a/array_sparse.go
+++ b/array_sparse.go
@@ -541,6 +541,9 @@ func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, err
 
 	inc, err := a.baseObject.MemUsage(ctx)
 	memUsage += inc
+	if err != nil {
+		return memUsage, err
+	}
 
 	if ctx.ArrayLenExceedsThreshold(len(a.items)) {
 		inc, err := a.estimateMemUsage(ctx)

--- a/array_sparse.go
+++ b/array_sparse.go
@@ -499,6 +499,33 @@ func (a *sparseArrayObject) exportToArrayOrSlice(dst reflect.Value, typ reflect.
 	return a.baseObject.exportToArrayOrSlice(dst, typ, ctx)
 }
 
+// estimateMemUsage helps calculating mem usage for large sparse arrays.
+// It will sample the array and use those samples to estimate the total
+// mem usage.
+func (a *sparseArrayObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, err error) {
+	var samplesVisited, memUsage uint64
+	totalItems := len(a.items)
+	if totalItems == 0 {
+		return memUsage, nil
+	}
+	sampleSize := totalItems / 10
+
+	// grabbing one sample every "sampleSize" to provide consistent
+	// memory usage across function executions
+	for i := 0; i < totalItems; i += sampleSize {
+		v := a.items[i].value
+		inc, err := v.MemUsage(ctx)
+		samplesVisited += 1
+		// We add both the mem usage of the value and its index
+		memUsage += inc + SizeUint32
+		if err != nil {
+			return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), err
+		}
+	}
+
+	return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), nil
+}
+
 func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, err error) {
 	if a == nil || ctx.IsObjVisited(a) {
 		return SizeEmptyStruct, nil
@@ -512,9 +539,23 @@ func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, err
 	// sparseArrayObject overhead
 	memUsage = SizeEmptyStruct
 
+	inc, err := a.baseObject.MemUsage(ctx)
+	memUsage += inc
+
+	if ctx.ArrayLenExceedsThreshold(len(a.items)) {
+		inc, err := a.estimateMemUsage(ctx)
+		memUsage += inc
+		if err != nil {
+			return memUsage, err
+		}
+
+		ctx.Ascend()
+		return memUsage, nil
+	}
+
 	for _, item := range a.items {
 		// Add the size of the index
-		memUsage += SizeInt32
+		memUsage += SizeUint32
 		if item.value != nil {
 			inc, err := item.value.MemUsage(ctx)
 			memUsage += inc
@@ -529,7 +570,5 @@ func (a *sparseArrayObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, err
 
 	ctx.Ascend()
 
-	inc, err := a.baseObject.MemUsage(ctx)
-
-	return memUsage + inc, err
+	return memUsage, err
 }

--- a/array_sparse_test.go
+++ b/array_sparse_test.go
@@ -284,7 +284,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 				},
 			},
 			// array overhead + index size + (string len + overhead) + sparseArray baseObject
-			expected:    SizeEmptyStruct + SizeInt32 + (3 + SizeString) + SizeEmptyStruct,
+			expected:    SizeEmptyStruct + SizeUint32 + (3 + SizeString) + SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
@@ -325,8 +325,59 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 					},
 				},
 			},
-			// array overhead + index size + (string len + overhead) (we reach the limit at 4)
-			expected:    SizeEmptyStruct + (SizeInt32+(4+SizeString))*4,
+			// baseObject overhead + array overhead + index size + (string len + overhead) (we reach the limit at 4)
+			expected:    SizeEmptyStruct + SizeEmptyStruct + (SizeUint32+(4+SizeString))*4,
+			errExpected: nil,
+		},
+		{
+			name: "mem above estimate threshold and within memory limit returns correct usage",
+			mu:   NewMemUsageContext(vm, 88, 100, 5, 50, TestNativeMemUsageChecker{}),
+			sao: &sparseArrayObject{
+				items: []sparseArrayItem{
+					{
+						idx:   1,
+						value: vm.ToValue("key0"),
+					},
+					{
+						idx:   2,
+						value: vm.ToValue("key1"),
+					},
+					{
+						idx:   3,
+						value: vm.ToValue("key2"),
+					},
+					{
+						idx:   4,
+						value: vm.ToValue("key3"),
+					},
+					{
+						idx:   5,
+						value: vm.ToValue("key4"),
+					},
+					{
+						idx:   6,
+						value: vm.ToValue("key5"),
+					},
+					{
+						idx:   7,
+						value: vm.ToValue("key6"),
+					},
+					{
+						idx:   8,
+						value: vm.ToValue("key7"),
+					},
+					{
+						idx:   9,
+						value: vm.ToValue("key8"),
+					},
+					{
+						idx:   10,
+						value: vm.ToValue("key9"),
+					},
+				},
+			},
+			// baseObject overhead + array overhead + index size + (string len + overhead) (we reach the limit at 1)
+			expected:    SizeEmptyStruct + SizeEmptyStruct + (SizeUint32+(4+SizeString))*10,
 			errExpected: nil,
 		},
 	}

--- a/value.go
+++ b/value.go
@@ -131,6 +131,7 @@ const (
 	SizeNumber      = uint64(unsafe.Sizeof(float64(0)))
 	SizeInt32       = uint64(unsafe.Sizeof(int32(0)))
 	SizeInt         = uint64(unsafe.Sizeof(int(0)))
+	SizeUint32      = uint64(unsafe.Sizeof(uint32(0)))
 	SizeEmptyStruct = uint64(unsafe.Sizeof((*baseObject)(nil)))
 	SizeEmptySlice  = uint64(unsafe.Sizeof([]Value{}))
 	// SizeString allows us to take into account the 16 additional bytes


### PR DESCRIPTION
Adding the SizeUint32 was probably unnecessary =D