### PR TITLE
BAAS-22176: add mem usage estimation for map objects

### DIFF
--- a/added_values_test.go
+++ b/added_values_test.go
@@ -77,7 +77,7 @@ func TestAddedValuesMemUsage(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, nil))
+			mem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, 0.1, nil))
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}

--- a/array.go
+++ b/array.go
@@ -580,7 +580,7 @@ func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, e
 	if arrayLen == 0 {
 		return memUsage, nil
 	}
-	sampleSize := arrayLen / 10
+	sampleSize := int(math.Floor(float64(arrayLen) * SampleRate))
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/array.go
+++ b/array.go
@@ -580,7 +580,7 @@ func (a *arrayObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, e
 	if arrayLen == 0 {
 		return memUsage, nil
 	}
-	sampleSize := int(math.Floor(float64(arrayLen) * SampleRate))
+	sampleSize := ctx.ComputeSampleStep(arrayLen)
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/array_sparse.go
+++ b/array_sparse.go
@@ -508,7 +508,7 @@ func (a *sparseArrayObject) estimateMemUsage(ctx *MemUsageContext) (estimate uin
 	if totalItems == 0 {
 		return memUsage, nil
 	}
-	sampleSize := totalItems / 10
+	sampleSize := ctx.ComputeSampleStep(totalItems)
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/array_sparse_test.go
+++ b/array_sparse_test.go
@@ -274,7 +274,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao: &sparseArrayObject{
 				items: []sparseArrayItem{
 					{
@@ -289,14 +289,14 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name:        "mem is SizeEmptyStruct for nil sparse array",
-			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao:         nil,
 			expected:    SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao: &sparseArrayObject{
 				items: []sparseArrayItem{
 					{
@@ -331,7 +331,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem above estimate threshold and within memory limit returns correct usage",
-			mu:   NewMemUsageContext(vm, 88, 100, 5, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 5, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao: &sparseArrayObject{
 				items: []sparseArrayItem{
 					{

--- a/array_test.go
+++ b/array_test.go
@@ -144,7 +144,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold given a nil slice of values",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao:   &arrayObject{},
 			// array overhead + array baseObject
 			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
@@ -152,7 +152,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem below threshold given empty slice of values",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao:   &arrayObject{values: []Value{}},
 			// array overhead + array baseObject + values slice overhead
 			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice,
@@ -160,7 +160,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{
 					vm.ToValue("key0"),
@@ -179,7 +179,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "empty array with negative threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, -1, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, -1, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{},
 			},

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -1,6 +1,7 @@
 package goja
 
 import (
+	"math"
 	"reflect"
 )
 
@@ -94,6 +95,40 @@ func (mo *mapObject) exportToMap(dst reflect.Value, typ reflect.Type, ctx *objec
 	return nil
 }
 
+// estimateMemUsage helps calculating mem usage for large objects.
+// It will sample the object and use those samples to estimate the
+// mem usage.
+func (mo *mapObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, err error) {
+	var samplesVisited, memUsage uint64
+	totalItems := mo.m.size
+	if totalItems == 0 {
+		return memUsage, nil
+	}
+	sampleSize := int(math.Floor(float64(totalItems) * SampleRate))
+
+	i := 0
+	for item := mo.m.iterFirst; item != nil && i < totalItems; item = item.iterNext {
+		if i%sampleSize != 0 {
+			continue
+		}
+		samplesVisited += 1
+		inc, err := item.key.MemUsage(ctx)
+		memUsage += inc
+		if err != nil {
+			return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), err
+		}
+
+		inc, err = item.value.MemUsage(ctx)
+		memUsage += inc
+		if err != nil {
+			return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), err
+		}
+		i += 1
+	}
+
+	return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), nil
+}
+
 func (mo *mapObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, err error) {
 	if mo == nil || ctx.IsObjVisited(mo) {
 		return SizeEmptyStruct, nil
@@ -109,28 +144,36 @@ func (mo *mapObject) MemUsage(ctx *MemUsageContext) (memUsage uint64, err error)
 		return memUsage, err
 	}
 
-	for _, entry := range mo.m.hashTable {
-		if entry == nil {
-			continue
+	if ctx.ObjectPropsLenExceedsThreshold(mo.m.size) {
+		inc, err := mo.estimateMemUsage(ctx)
+		memUsage += inc
+		if err != nil {
+			return memUsage, err
 		}
-
-		if entry.key != nil {
-			inc, err := entry.key.MemUsage(ctx)
-			memUsage += inc
-			if err != nil {
-				return memUsage, err
+	} else {
+		for _, entry := range mo.m.hashTable {
+			if entry == nil {
+				continue
 			}
-		}
 
-		if entry.value != nil {
-			inc, err := entry.value.MemUsage(ctx)
-			memUsage += inc
-			if err != nil {
-				return memUsage, err
+			if entry.key != nil {
+				inc, err := entry.key.MemUsage(ctx)
+				memUsage += inc
+				if err != nil {
+					return memUsage, err
+				}
 			}
-		}
-		if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
-			return memUsage, nil
+
+			if entry.value != nil {
+				inc, err := entry.value.MemUsage(ctx)
+				memUsage += inc
+				if err != nil {
+					return memUsage, err
+				}
+			}
+			if exceeded := ctx.MemUsageLimitExceeded(memUsage); exceeded {
+				return memUsage, nil
+			}
 		}
 	}
 

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -1,7 +1,6 @@
 package goja
 
 import (
-	"math"
 	"reflect"
 )
 
@@ -104,11 +103,12 @@ func (mo *mapObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, er
 	if totalItems == 0 {
 		return memUsage, nil
 	}
-	sampleSize := int(math.Floor(float64(totalItems) * SampleRate))
+	sampleSize := ctx.ComputeSampleStep(totalItems)
 
-	i := 0
-	for item := mo.m.iterFirst; item != nil && i < totalItems; item = item.iterNext {
-		if i%sampleSize != 0 {
+	// We can use samplesVisited instead of an index since we iterate using
+	// iterNext
+	for item := mo.m.iterFirst; item != nil && samplesVisited < uint64(totalItems); item = item.iterNext {
+		if samplesVisited%uint64(sampleSize) != 0 {
 			continue
 		}
 		samplesVisited += 1
@@ -123,7 +123,6 @@ func (mo *mapObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, er
 		if err != nil {
 			return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), err
 		}
-		i += 1
 	}
 
 	return computeMemUsageEstimate(memUsage, samplesVisited, totalItems), nil

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -3,7 +3,6 @@ package goja
 import (
 	"fmt"
 	"hash/maphash"
-	"math"
 	"testing"
 )
 
@@ -252,7 +251,7 @@ func createOrderedMap(vm *Runtime, size int) *orderedMap {
 		// We intentionally set the non-sampled items to something different
 		// so that we can show in our test that we are correctly using
 		// the samples to estimate mem usage and nothing else.
-		if i%(int(math.Floor(float64(size)*SampleRate))) == 1 {
+		if i%(computeSampleStep(size, 0.1)) == 1 {
 			value = vm.ToValue("verylongstring")
 		}
 
@@ -287,7 +286,7 @@ func TestMapObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
@@ -304,14 +303,14 @@ func TestMapObjectMemUsage(t *testing.T) {
 		},
 		{
 			name:        "mem is SizeEmptyStruct given a nil map object",
-			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, TestNativeMemUsageChecker{}),
+			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			mo:          nil,
 			expectedMem: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
@@ -344,7 +343,7 @@ func TestMapObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem above estimate threshold and within memory limit returns correct mem usage",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 5, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 5, 0.1, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: createOrderedMap(vm, 20),
 			},

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -3,6 +3,7 @@ package goja
 import (
 	"fmt"
 	"hash/maphash"
+	"math"
 	"testing"
 )
 
@@ -243,8 +244,40 @@ func BenchmarkMapDeleteJS(b *testing.B) {
 	}
 }
 
+func createOrderedMap(vm *Runtime, size int) *orderedMap {
+	ht := make(map[uint64]*mapEntry, 0)
+	for i := 0; i < size; i += 1 {
+		value := vm.ToValue("value")
+		// This is leveraging the fact that we sample only 10% of the data.
+		// We intentionally set the non-sampled items to something different
+		// so that we can show in our test that we are correctly using
+		// the samples to estimate mem usage and nothing else.
+		if i%(int(math.Floor(float64(size)*SampleRate))) == 1 {
+			value = vm.ToValue("verylongstring")
+		}
+
+		ht[uint64(i)] = &mapEntry{
+			key:   vm.ToValue("key"),
+			value: value,
+		}
+		// These iter items are necessary for testing the mem usage
+		// estimation since that's who we iterate through the map.
+		if i > 0 {
+			ht[uint64(i)].iterPrev = ht[uint64(i-1)]
+			ht[uint64(i-1)].iterNext = ht[uint64(i)]
+		}
+	}
+	return &orderedMap{
+		size:      size,
+		iterFirst: ht[uint64(0)],
+		iterLast:  ht[uint64(size-1)],
+		hashTable: ht,
+	}
+}
+
 func TestMapObjectMemUsage(t *testing.T) {
 	vm := New()
+
 	tests := []struct {
 		name        string
 		mu          *MemUsageContext
@@ -307,6 +340,20 @@ func TestMapObjectMemUsage(t *testing.T) {
 				(3+SizeString)*3 +
 				// len(value) + overhead (we reach the limit after 3)
 				(5+SizeString)*3,
+			errExpected: nil,
+		},
+		{
+			name: "mem above estimate threshold and within memory limit returns correct mem usage",
+			mu:   NewMemUsageContext(vm, 88, 100, 50, 5, TestNativeMemUsageChecker{}),
+			mo: &mapObject{
+				m: createOrderedMap(vm, 20),
+			},
+			// baseObject
+			expectedMem: SizeEmptyStruct +
+				// len(key) + overhead (we reach the limit after 3)
+				(3+SizeString)*20 +
+				// len(value) + overhead (we reach the limit after 3)
+				(5+SizeString)*20,
 			errExpected: nil,
 		},
 	}

--- a/builtin_proxy_test.go
+++ b/builtin_proxy_test.go
@@ -1290,7 +1290,7 @@ func TestBuiltinProxyMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5657,7 +5657,7 @@ func TestProgramMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(New(), 88, 50, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(New(), 88, 50, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			p: &Program{
 				values: []Value{
 					New().newDateObject(time.Now(), true, nil),
@@ -5669,7 +5669,7 @@ func TestProgramMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(New(), 88, 50, 50, 50, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(New(), 88, 50, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			p: &Program{
 				values: []Value{
 					New().newDateObject(time.Now(), true, nil),

--- a/date_test.go
+++ b/date_test.go
@@ -349,7 +349,7 @@ func TestDateMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/destruct_test.go
+++ b/destruct_test.go
@@ -27,7 +27,7 @@ func TestDestructMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/func_test.go
+++ b/func_test.go
@@ -184,7 +184,7 @@ func TestNativeFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -234,7 +234,7 @@ func TestFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/mem_context.go
+++ b/mem_context.go
@@ -95,6 +95,8 @@ func (m *MemUsageContext) MemUsageLimitExceeded(memUsage uint64) bool {
 
 var (
 	ErrMaxDepth = errors.New("reached max depth")
+	// SampleRate represents the percentage of samples we pick up to estimate mem usage
+	SampleRate = 0.1
 )
 
 type MemUsageReporter interface {

--- a/mem_context.go
+++ b/mem_context.go
@@ -2,6 +2,7 @@ package goja
 
 import (
 	"errors"
+	"math"
 )
 
 type visitTracker struct {
@@ -61,6 +62,7 @@ type MemUsageContext struct {
 	NativeMemUsageChecker
 	ArrayLenExceedsThreshold       func(arrayLen int) bool
 	ObjectPropsLenExceedsThreshold func(objPropsLen int) bool
+	ComputeSampleStep              func(totalItems int) int
 	memoryLimit                    uint64
 }
 
@@ -69,6 +71,7 @@ func NewMemUsageContext(
 	maxDepth int,
 	memLimit uint64,
 	arrayLenThreshold, objPropsLenThreshold int,
+	sampleRate float64,
 	nativeChecker NativeMemUsageChecker,
 ) *MemUsageContext {
 	return &MemUsageContext{
@@ -84,6 +87,9 @@ func NewMemUsageContext(
 			// number of obj props beyond which we should estimate mem usage
 			return objPropsLen > objPropsLenThreshold
 		},
+		ComputeSampleStep: func(totalItems int) int {
+			return computeSampleStep(totalItems, sampleRate)
+		},
 	}
 }
 
@@ -93,10 +99,31 @@ func (m *MemUsageContext) MemUsageLimitExceeded(memUsage uint64) bool {
 	return memUsage > m.memoryLimit
 }
 
+func computeMemUsageEstimate(memUsage, samplesVisited uint64, totalProps int) uint64 {
+	// averageMemUsage * total object props
+	return uint64(float32(memUsage) / float32(samplesVisited) * float32(totalProps))
+}
+
+// computeSampleStep will take the total items we want to sample from and a sample rate.
+// It will use this value to determine the sample step, which indicates how often we need
+// to grab a sample. For example, with 100 total items and a 0.2 sample rate, it means
+// we want to sample 20% of 100 items, in order to do so we need to pick an item ever 5
+// (5 * 20 == 100)
+func computeSampleStep(totalItems int, sampleRate float64) int {
+	if sampleRate == 0 || totalItems == 0 {
+		return 1
+	}
+	if sampleRate >= 0.5 {
+		// We allow a max sample size half of the total items
+		sampleRate = 0.5
+	}
+
+	totalSamples := float64(totalItems) * sampleRate
+	return int(math.Floor(float64(totalItems) / totalSamples))
+}
+
 var (
 	ErrMaxDepth = errors.New("reached max depth")
-	// SampleRate represents the percentage of samples we pick up to estimate mem usage
-	SampleRate = 0.1
 )
 
 type MemUsageReporter interface {

--- a/mem_context_test.go
+++ b/mem_context_test.go
@@ -36,3 +36,30 @@ func TestMemUsageLimitExceeded(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeSampleStep(t *testing.T) {
+	tests := []struct {
+		name       string
+		totalItems int
+		sampleRate float64
+		expected   int
+	}{
+		{"should compute sample size given 10 items and 10% rate", 100, 0.1, 10},
+		{"should compute sample size given 10 items and 20% rate", 100, 0.2, 5},
+		{"should compute sample size given 10 items and 50% rate", 100, 0.5, 2},
+		{"should compute sample size of 5 given 10 items and 70% rate", 100, 0.7, 2},
+		{"should compute sample size of 5 given 10 items and 100% rate", 100, 1, 2},
+		{"should compute sample size of 5 given 10 items and 150% rate", 100, 1.5, 2},
+		{"should compute sample size of 1 given 0 items and 50% rate", 0, 0.5, 1},
+		{"should compute sample size of 1 given 10 items and 0% rate", 100, 0, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := computeSampleStep(tc.totalItems, tc.sampleRate)
+			if actual != tc.expected {
+				t.Fatalf("ACTUAL: %v EXPECTED: %v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/memory_test.go
+++ b/memory_test.go
@@ -402,7 +402,7 @@ func TestMemCheck(t *testing.T) {
 
 			vm.Set("checkMem", func(call FunctionCall) Value {
 				mem, err := vm.MemUsage(
-					NewMemUsageContext(vm, 100, memUsageLimit, arrLenThreshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
+					NewMemUsageContext(vm, 100, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -473,7 +473,7 @@ func TestMemMaxDepth(t *testing.T) {
 			// All global variables are contained in the Runtime's globalObject field, which causes
 			// them to be one level deeper
 			_, err = vm.MemUsage(
-				NewMemUsageContext(vm, tc.expectedDepth, memUsageLimit, arrLenThreshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
+				NewMemUsageContext(vm, tc.expectedDepth, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 			)
 			if err != ErrMaxDepth {
 				t.Fatalf("expected mem check to hit depth limit error, but got nil %v", err)
@@ -481,7 +481,7 @@ func TestMemMaxDepth(t *testing.T) {
 
 			_, err = vm.MemUsage(
 				// need to add 2 to the expectedDepth since Object is lazy loaded it adds onto the expected depth
-				NewMemUsageContext(vm, tc.expectedDepth+2, memUsageLimit, arrLenThreshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
+				NewMemUsageContext(vm, tc.expectedDepth+2, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 			)
 			if err != nil {
 				t.Fatalf("expected to NOT hit mem check hit depth limit error, but got %v", err)
@@ -498,96 +498,96 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 		memLimit         uint64
 		expectedSizeDiff uint64
 	}{
-		{
-			desc: "array of numbers under length threshold",
-			script: `y = []
-			y.push([]);
-			let i=0;
-			checkMem();
-			for(i=0;i<20;i++){
-				y[0].push(i);
-			};
-			checkMem()`,
-			threshold: 100,
-			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmptyStruct + // Array overhead
-				20*SizeNumber, // size of property values
-		},
-		{
-			desc: "array of numbers over threshold",
-			script: `y = []
-			y.push([]);
-			let i=0;
-			checkMem();
-			for(i=0;i<200;i++){
-				y[0].push(i);
-			};
-			checkMem()`,
-			threshold: 100,
-			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmptyStruct + // Array overhead
-				200*SizeNumber, // size of property values
-		},
-		{
-			desc: "mixed array under threshold",
-			script: `y = []
-			y.push([]);
-			let i = 0;
-			checkMem();
-			for(i=0;i<100;i++){
-				y[0].push(i<50?0:true);
-			};
-			checkMem()`,
-			threshold: 200,
-			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmptyStruct + // Array overhead
-				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
-				// stack difference in going from
-				//	[..other, []]
-				//  to
-				//	[..other, true, 50]
-				+1,
-		},
+		// {
+		// 	desc: "array of numbers under length threshold",
+		// 	script: `y = []
+		// 	y.push([]);
+		// 	let i=0;
+		// 	checkMem();
+		// 	for(i=0;i<20;i++){
+		// 		y[0].push(i);
+		// 	};
+		// 	checkMem()`,
+		// 	threshold: 100,
+		// 	memLimit:  memUsageLimit,
+		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead
+		// 		20*SizeNumber, // size of property values
+		// },
+		// {
+		// 	desc: "array of numbers over threshold",
+		// 	script: `y = []
+		// 	y.push([]);
+		// 	let i=0;
+		// 	checkMem();
+		// 	for(i=0;i<200;i++){
+		// 		y[0].push(i);
+		// 	};
+		// 	checkMem()`,
+		// 	threshold: 100,
+		// 	memLimit:  memUsageLimit,
+		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead
+		// 		200*SizeNumber, // size of property values
+		// },
+		// {
+		// 	desc: "mixed array under threshold",
+		// 	script: `y = []
+		// 	y.push([]);
+		// 	let i = 0;
+		// 	checkMem();
+		// 	for(i=0;i<100;i++){
+		// 		y[0].push(i<50?0:true);
+		// 	};
+		// 	checkMem()`,
+		// 	threshold: 200,
+		// 	memLimit:  memUsageLimit,
+		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead
+		// 		(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+		// 		// stack difference in going from
+		// 		//	[..other, []]
+		// 		//  to
+		// 		//	[..other, true, 50]
+		// 		+1,
+		// },
 		{
 			desc: "mixed array over threshold",
 			script: `y = []
 			y.push([]);
 			let i = 0;
 			checkMem();
-			for(i=0;i<100;i++){
-				y[0].push(i<50?0:true);
+			for(i=0;i<20;i++){
+				y[0].push(i<10?0:true);
 			};
 			checkMem()`,
-			threshold: 50,
+			threshold: 10,
 			memLimit:  memUsageLimit,
 			expectedSizeDiff: SizeEmptyStruct + // Array overhead
-				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+				(10 * SizeNumber) + (10 * SizeBool) + // (450) size of property values
 				// stack difference in going from
 				//	[..other, []]
 				//  to
 				//	[..other, true, 50]
 				+1,
 		},
-		{
-			desc: "mixed scattered array over threshold wcs",
-			script: `y = []
-			y.push([]);
-			let i = 0;
-			checkMem();
-			for(i=0;i < 100;i++){
-				y[0].push(i%10==0?0:true);
-			};
-			checkMem()`,
-			threshold: 50,
-			memLimit:  memUsageLimit,
-			expectedSizeDiff: SizeEmptyStruct + // Array overhead,
-				(100 * SizeNumber) + // size of property values
-				// stack difference in going from
-				//	[..other, []]
-				//  to
-				//	[..other, true, 50]
-				+1,
-		},
+		// {
+		// 	desc: "mixed scattered array over threshold wcs",
+		// 	script: `y = []
+		// 	y.push([]);
+		// 	let i = 0;
+		// 	checkMem();
+		// 	for(i=0;i < 100;i++){
+		// 		y[0].push(i%10==0?0:true);
+		// 	};
+		// 	checkMem()`,
+		// 	threshold: 50,
+		// 	memLimit:  memUsageLimit,
+		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead,
+		// 		(100 * SizeNumber) + // size of property values
+		// 		// stack difference in going from
+		// 		//	[..other, []]
+		// 		//  to
+		// 		//	[..other, true, 50]
+		// 		+1,
+		// },
 	} {
 		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			memChecks := []uint64{}
@@ -595,7 +595,7 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 
 			vm.Set("checkMem", func(call FunctionCall) Value {
 				mem, err := vm.MemUsage(
-					NewMemUsageContext(vm, 100, tc.memLimit, tc.threshold, objPropsLenThreshold, TestNativeMemUsageChecker{}),
+					NewMemUsageContext(vm, 100, tc.memLimit, tc.threshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -686,7 +686,7 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 
 			vm.Set("checkMem", func(call FunctionCall) Value {
 				mem, err := vm.MemUsage(
-					NewMemUsageContext(vm, 100, tc.memLimit, arrLenThreshold, tc.threshold, TestNativeMemUsageChecker{}),
+					NewMemUsageContext(vm, 100, tc.memLimit, arrLenThreshold, tc.threshold, 0.1, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)

--- a/memory_test.go
+++ b/memory_test.go
@@ -498,56 +498,56 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 		memLimit         uint64
 		expectedSizeDiff uint64
 	}{
-		// {
-		// 	desc: "array of numbers under length threshold",
-		// 	script: `y = []
-		// 	y.push([]);
-		// 	let i=0;
-		// 	checkMem();
-		// 	for(i=0;i<20;i++){
-		// 		y[0].push(i);
-		// 	};
-		// 	checkMem()`,
-		// 	threshold: 100,
-		// 	memLimit:  memUsageLimit,
-		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead
-		// 		20*SizeNumber, // size of property values
-		// },
-		// {
-		// 	desc: "array of numbers over threshold",
-		// 	script: `y = []
-		// 	y.push([]);
-		// 	let i=0;
-		// 	checkMem();
-		// 	for(i=0;i<200;i++){
-		// 		y[0].push(i);
-		// 	};
-		// 	checkMem()`,
-		// 	threshold: 100,
-		// 	memLimit:  memUsageLimit,
-		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead
-		// 		200*SizeNumber, // size of property values
-		// },
-		// {
-		// 	desc: "mixed array under threshold",
-		// 	script: `y = []
-		// 	y.push([]);
-		// 	let i = 0;
-		// 	checkMem();
-		// 	for(i=0;i<100;i++){
-		// 		y[0].push(i<50?0:true);
-		// 	};
-		// 	checkMem()`,
-		// 	threshold: 200,
-		// 	memLimit:  memUsageLimit,
-		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead
-		// 		(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
-		// 		// stack difference in going from
-		// 		//	[..other, []]
-		// 		//  to
-		// 		//	[..other, true, 50]
-		// 		+1,
-		// },
+		{
+			desc: "array of numbers under length threshold",
+			script: `y = []
+			y.push([]);
+			let i=0;
+			checkMem();
+			for(i=0;i<20;i++){
+				y[0].push(i);
+			};
+			checkMem()`,
+			threshold: 100,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
+				20*SizeNumber, // size of property values
+		},
+		{
+			desc: "array of numbers over threshold",
+			script: `y = []
+			y.push([]);
+			let i=0;
+			checkMem();
+			for(i=0;i<200;i++){
+				y[0].push(i);
+			};
+			checkMem()`,
+			threshold: 100,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
+				200*SizeNumber, // size of property values
+		},
+		{
+			desc: "mixed array under threshold",
+			script: `y = []
+			y.push([]);
+			let i = 0;
+			checkMem();
+			for(i=0;i<100;i++){
+				y[0].push(i<50?0:true);
+			};
+			checkMem()`,
+			threshold: 200,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead
+				(50 * SizeNumber) + (50 * SizeBool) + // (450) size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
+		},
 		{
 			desc: "mixed array over threshold",
 			script: `y = []
@@ -568,26 +568,26 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 				//	[..other, true, 50]
 				+1,
 		},
-		// {
-		// 	desc: "mixed scattered array over threshold wcs",
-		// 	script: `y = []
-		// 	y.push([]);
-		// 	let i = 0;
-		// 	checkMem();
-		// 	for(i=0;i < 100;i++){
-		// 		y[0].push(i%10==0?0:true);
-		// 	};
-		// 	checkMem()`,
-		// 	threshold: 50,
-		// 	memLimit:  memUsageLimit,
-		// 	expectedSizeDiff: SizeEmptyStruct + // Array overhead,
-		// 		(100 * SizeNumber) + // size of property values
-		// 		// stack difference in going from
-		// 		//	[..other, []]
-		// 		//  to
-		// 		//	[..other, true, 50]
-		// 		+1,
-		// },
+		{
+			desc: "mixed scattered array over threshold wcs",
+			script: `y = []
+			y.push([]);
+			let i = 0;
+			checkMem();
+			for(i=0;i < 100;i++){
+				y[0].push(i%10==0?0:true);
+			};
+			checkMem()`,
+			threshold: 50,
+			memLimit:  memUsageLimit,
+			expectedSizeDiff: SizeEmptyStruct + // Array overhead,
+				(100 * SizeNumber) + // size of property values
+				// stack difference in going from
+				//	[..other, []]
+				//  to
+				//	[..other, true, 50]
+				+1,
+		},
 	} {
 		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			memChecks := []uint64{}

--- a/object.go
+++ b/object.go
@@ -1919,7 +1919,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, er
 	if totalProps == 0 {
 		return memUsage, nil
 	}
-	sampleSize := totalProps / 10
+	sampleSize := int(math.Floor(float64(totalProps) * SampleRate))
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/object.go
+++ b/object.go
@@ -1905,11 +1905,6 @@ func (i *privateId) string() unistring.String {
 	return privateIdString(i.name)
 }
 
-func computeMemUsageEstimate(memUsage, samplesVisited uint64, totalProps int) uint64 {
-	// averageMemUsage * total object props
-	return uint64(float32(memUsage) / float32(samplesVisited) * float32(totalProps))
-}
-
 // estimateMemUsage helps calculating mem usage for large objects.
 // It will sample the object and use those samples to estimate the
 // mem usage.
@@ -1919,7 +1914,7 @@ func (o *baseObject) estimateMemUsage(ctx *MemUsageContext) (estimate uint64, er
 	if totalProps == 0 {
 		return memUsage, nil
 	}
-	sampleSize := int(math.Floor(float64(totalProps) * SampleRate))
+	sampleSize := ctx.ComputeSampleStep(totalProps)
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/object_dynamic_test.go
+++ b/object_dynamic_test.go
@@ -460,7 +460,7 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -503,7 +503,7 @@ func TestDynamicArrayMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_gomap.go
+++ b/object_gomap.go
@@ -1,7 +1,6 @@
 package goja
 
 import (
-	"math"
 	"reflect"
 
 	"github.com/dop251/goja/unistring"
@@ -168,7 +167,7 @@ func (o *objectGoMapSimple) estimateMemUsage(ctx *MemUsageContext) (estimate uin
 	if totalProps == 0 {
 		return memUsage, nil
 	}
-	sampleSize := int(math.Floor(float64(totalProps) * SampleRate))
+	sampleSize := ctx.ComputeSampleStep(totalProps)
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/object_gomap.go
+++ b/object_gomap.go
@@ -1,6 +1,7 @@
 package goja
 
 import (
+	"math"
 	"reflect"
 
 	"github.com/dop251/goja/unistring"
@@ -167,7 +168,7 @@ func (o *objectGoMapSimple) estimateMemUsage(ctx *MemUsageContext) (estimate uin
 	if totalProps == 0 {
 		return memUsage, nil
 	}
-	sampleSize := totalProps / 10
+	sampleSize := int(math.Floor(float64(totalProps) * SampleRate))
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/object_gomap_test.go
+++ b/object_gomap_test.go
@@ -331,7 +331,7 @@ func TestGoMapUnicode(t *testing.T) {
 
 func TestGoMapMemUsage(t *testing.T) {
 	vm := New()
-	vmCtx := NewMemUsageContext(vm, 100, 100, 100, 100, nil)
+	vmCtx := NewMemUsageContext(vm, 100, 100, 100, 100, 0.1, nil)
 
 	nestedMap := map[string]interface{}{
 		"subTest1": valueInt(99),
@@ -503,7 +503,7 @@ func TestGoMapMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, tc.memLimit, 100, tc.estimateThreshold, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, tc.memLimit, 100, tc.estimateThreshold, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_goslice.go
+++ b/object_goslice.go
@@ -357,7 +357,7 @@ func (o *objectGoSlice) estimateMemUsage(ctx *MemUsageContext) (estimate uint64,
 	if sliceLen == 0 {
 		return memUsage, nil
 	}
-	sampleSize := int(math.Floor(float64(sliceLen) * SampleRate))
+	sampleSize := ctx.ComputeSampleStep(sliceLen)
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/object_goslice.go
+++ b/object_goslice.go
@@ -357,7 +357,7 @@ func (o *objectGoSlice) estimateMemUsage(ctx *MemUsageContext) (estimate uint64,
 	if sliceLen == 0 {
 		return memUsage, nil
 	}
-	sampleSize := sliceLen / 10
+	sampleSize := int(math.Floor(float64(sliceLen) * SampleRate))
 
 	// grabbing one sample every "sampleSize" to provide consistent
 	// memory usage across function executions

--- a/object_goslice_test.go
+++ b/object_goslice_test.go
@@ -442,7 +442,7 @@ func TestGoSliceMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, tc.memLimit, tc.estimateThreshold, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, tc.memLimit, tc.estimateThreshold, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_test.go
+++ b/object_test.go
@@ -758,7 +758,7 @@ func TestBaseObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, tc.threshold, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, tc.threshold, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -816,7 +816,7 @@ func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -68,7 +68,7 @@ func TestProxyMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -116,7 +116,7 @@ func TestJSProxyHandlerMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3182,7 +3182,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/string_ascii_test.go
+++ b/string_ascii_test.go
@@ -27,7 +27,7 @@ func TestStringAsciiMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/string_imported_test.go
+++ b/string_imported_test.go
@@ -27,7 +27,7 @@ func TestStringImportedMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/string_test.go
+++ b/string_test.go
@@ -186,7 +186,7 @@ func TestStringObjectMemUsage(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, nil))
+			mem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, 0.1, nil))
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}

--- a/string_unicode_test.go
+++ b/string_unicode_test.go
@@ -27,7 +27,7 @@ func TestStringUnicodeMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -386,7 +386,7 @@ func TestArrayBufferObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -471,7 +471,7 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -538,7 +538,7 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/value_test.go
+++ b/value_test.go
@@ -110,7 +110,7 @@ func TestValueMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -167,7 +167,7 @@ func TestValuePropertyMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -278,7 +278,7 @@ func TestObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/vm_test.go
+++ b/vm_test.go
@@ -425,7 +425,7 @@ func TestValueStackMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -485,7 +485,7 @@ func TestVMContextMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -547,7 +547,7 @@ func TestStashMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}


### PR DESCRIPTION
As a drive-by I defined a sample rate that is easier to manage across all estimates, I think eventually we could pass it as a param to make our tests simpler.