### PR TITLE
BAAS-34801: add forced mem checks on new arrays and obj props

### DIFF
--- a/added_values_test.go
+++ b/added_values_test.go
@@ -48,8 +48,6 @@ func TestIntStringEquality(t *testing.T) {
 }
 
 func TestAddedValuesMemUsage(t *testing.T) {
-	vm := New()
-
 	for _, tc := range []struct {
 		name        string
 		val         MemUsageReporter
@@ -77,7 +75,7 @@ func TestAddedValuesMemUsage(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, 0.1, nil))
+			mem, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}

--- a/array_sparse_test.go
+++ b/array_sparse_test.go
@@ -274,7 +274,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao: &sparseArrayObject{
 				items: []sparseArrayItem{
 					{
@@ -289,14 +289,14 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name:        "mem is SizeEmptyStruct for nil sparse array",
-			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:          NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao:         nil,
 			expected:    SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao: &sparseArrayObject{
 				items: []sparseArrayItem{
 					{
@@ -331,7 +331,7 @@ func TestSparseArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem above estimate threshold and within memory limit returns correct usage",
-			mu:   NewMemUsageContext(vm, 88, 100, 5, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 5, 50, 0.1, TestNativeMemUsageChecker{}),
 			sao: &sparseArrayObject{
 				items: []sparseArrayItem{
 					{

--- a/array_test.go
+++ b/array_test.go
@@ -144,7 +144,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold given a nil slice of values",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao:   &arrayObject{},
 			// array overhead + array baseObject
 			expectedMem: SizeEmptyStruct + SizeEmptyStruct,
@@ -152,7 +152,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem below threshold given empty slice of values",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao:   &arrayObject{values: []Value{}},
 			// array overhead + array baseObject + values slice overhead
 			expectedMem: SizeEmptyStruct + SizeEmptyStruct + SizeEmptySlice,
@@ -160,7 +160,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{
 					vm.ToValue("key0"),
@@ -179,7 +179,7 @@ func TestArrayObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "empty array with negative threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, -1, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, -1, 50, 0.1, TestNativeMemUsageChecker{}),
 			ao: &arrayObject{
 				values: []Value{},
 			},

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -81,7 +81,7 @@ func relToIdx(rel, l int64) int64 {
 }
 
 func (r *Runtime) newArrayValues(values valueStack) *Object {
-	if r.shouldForceMemCheck || true {
+	if r.shouldForceMemCheck {
 		if memCtx := newMemUsageContextClone(); memCtx != nil {
 			memUsage, err := valuesMemUsage(values, memCtx)
 			if err != nil {

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -89,7 +89,7 @@ func (r *Runtime) newArrayValues(values valueStack) *Object {
 				panic(err)
 			}
 			if memCtx.MemUsageLimitExceeded(memUsage) {
-				panic("memory limit exceeded")
+				panic(ErrMemLimitExceeded)
 			}
 		}
 	}

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -80,7 +80,19 @@ func relToIdx(rel, l int64) int64 {
 	return max(l+rel, 0)
 }
 
-func (r *Runtime) newArrayValues(values []Value) *Object {
+func (r *Runtime) newArrayValues(values valueStack) *Object {
+	if r.shouldForceMemCheck {
+		memCtx := newMemUsageContextClone()
+		if memCtx != nil {
+			memUsage, err := valuesMemUsage(values, memCtx)
+			if err != nil {
+				panic(err)
+			}
+			if memCtx.MemUsageLimitExceeded(memUsage) {
+				panic("memory limit exceeded")
+			}
+		}
+	}
 	return setArrayValues(r.newArrayObject(), values).val
 }
 

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -81,9 +81,8 @@ func relToIdx(rel, l int64) int64 {
 }
 
 func (r *Runtime) newArrayValues(values valueStack) *Object {
-	if r.shouldForceMemCheck {
-		memCtx := newMemUsageContextClone()
-		if memCtx != nil {
+	if r.shouldForceMemCheck || true {
+		if memCtx := newMemUsageContextClone(); memCtx != nil {
 			memUsage, err := valuesMemUsage(values, memCtx)
 			if err != nil {
 				panic(err)

--- a/builtin_arrray_test.go
+++ b/builtin_arrray_test.go
@@ -1,6 +1,9 @@
 package goja
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestArrayProtoProp(t *testing.T) {
 	const SCRIPT = `
@@ -337,4 +340,54 @@ func TestArrayProto(t *testing.T) {
 	assert(compareArray(a, [2, 3]));
 	`
 	testScriptWithTestLib(SCRIPT, _undefined, t)
+}
+
+func TestNewArrayValues(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		memLimit            uint64
+		expectedPanic       bool
+		shouldForceMemCheck bool
+	}{
+		{
+			name:                "should not panic when creating a new array under the mem limit",
+			memLimit:            1000,
+			expectedPanic:       false,
+			shouldForceMemCheck: false,
+		},
+		{
+			name:                "should panic when creating a new array over the mem limit and mem usage check is forced",
+			memLimit:            0,
+			expectedPanic:       true,
+			shouldForceMemCheck: true,
+		},
+		{
+			name:                "should not panic when creating a new array over the mem limit and mem usage check is not forced",
+			memLimit:            0,
+			expectedPanic:       false,
+			shouldForceMemCheck: false,
+		},
+		{
+			name:                "should not panic when creating a new array under the mem limit and mem usage check is forced",
+			memLimit:            1000,
+			expectedPanic:       false,
+			shouldForceMemCheck: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tc.expectedPanic && r == nil {
+					t.Error("The code is expected to panic, but it didn't")
+				}
+				if !tc.expectedPanic && r != nil {
+					t.Errorf("The code panicked, but it should not have: %v", r)
+				}
+			}()
+			vm := NewWithContext(context.Background(), tc.shouldForceMemCheck)
+			// Creating a mem usage context so it populates the package variable
+			NewMemUsageContext(100, tc.memLimit, 100, 100, 0.5, nil)
+			vm.newArrayValues([]Value{valueInt(0)})
+		})
+	}
 }

--- a/builtin_map_test.go
+++ b/builtin_map_test.go
@@ -286,7 +286,7 @@ func TestMapObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
@@ -303,14 +303,14 @@ func TestMapObjectMemUsage(t *testing.T) {
 		},
 		{
 			name:        "mem is SizeEmptyStruct given a nil map object",
-			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:          NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			mo:          nil,
 			expectedMem: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
@@ -343,7 +343,7 @@ func TestMapObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem above estimate threshold and within memory limit returns correct mem usage",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 5, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 5, 0.1, TestNativeMemUsageChecker{}),
 			mo: &mapObject{
 				m: createOrderedMap(vm, 20),
 			},

--- a/builtin_proxy_test.go
+++ b/builtin_proxy_test.go
@@ -1290,7 +1290,7 @@ func TestBuiltinProxyMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}

--- a/builtin_set_test.go
+++ b/builtin_set_test.go
@@ -227,7 +227,7 @@ func TestSetObjectMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			so: &setObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
@@ -244,14 +244,14 @@ func TestSetObjectMemUsage(t *testing.T) {
 		},
 		{
 			name:        "mem is SizeEmptyStruct given a nil map object",
-			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:          NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			so:          nil,
 			expectedMem: SizeEmptyStruct,
 			errExpected: nil,
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			so: &setObject{
 				m: &orderedMap{
 					hashTable: map[uint64]*mapEntry{
@@ -284,7 +284,7 @@ func TestSetObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem above estimate threshold and within memory limit returns correct mem usage",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 5, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 5, 0.1, TestNativeMemUsageChecker{}),
 			so: &setObject{
 				m: createOrderedMap(vm, 20),
 			},
@@ -298,7 +298,7 @@ func TestSetObjectMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem above estimate threshold and within memory limit and nil values returns correct mem usage",
-			mu:   NewMemUsageContext(vm, 88, 100, 50, 1, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 100, 50, 1, 0.1, TestNativeMemUsageChecker{}),
 			so: &setObject{
 				m: createOrderedMapWithNilValues(3),
 			},
@@ -308,7 +308,7 @@ func TestSetObjectMemUsage(t *testing.T) {
 		},
 		{
 			name:        "mem is SizeEmptyStruct given a nil orderedMap object",
-			mu:          NewMemUsageContext(vm, 88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:          NewMemUsageContext(88, 5000, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			so:          &setObject{},
 			expectedMem: SizeEmptyStruct,
 			errExpected: nil,

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5657,7 +5657,7 @@ func TestProgramMemUsage(t *testing.T) {
 	}{
 		{
 			name: "mem below threshold",
-			mu:   NewMemUsageContext(New(), 88, 50, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 50, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			p: &Program{
 				values: []Value{
 					New().newDateObject(time.Now(), true, nil),
@@ -5669,7 +5669,7 @@ func TestProgramMemUsage(t *testing.T) {
 		},
 		{
 			name: "mem way above threshold returns first crossing of threshold",
-			mu:   NewMemUsageContext(New(), 88, 50, 50, 50, 0.1, TestNativeMemUsageChecker{}),
+			mu:   NewMemUsageContext(88, 50, 50, 50, 0.1, TestNativeMemUsageChecker{}),
 			p: &Program{
 				values: []Value{
 					New().newDateObject(time.Now(), true, nil),

--- a/date_test.go
+++ b/date_test.go
@@ -349,7 +349,7 @@ func TestDateMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/destruct_test.go
+++ b/destruct_test.go
@@ -27,7 +27,7 @@ func TestDestructMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/func_test.go
+++ b/func_test.go
@@ -184,7 +184,7 @@ func TestNativeFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -234,7 +234,7 @@ func TestFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -282,7 +282,7 @@ func TestBaseJsFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -361,7 +361,7 @@ func TestClassFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -421,7 +421,7 @@ func TestMethodFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -490,7 +490,7 @@ func TestArrowFuncObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/mem_context.go
+++ b/mem_context.go
@@ -3,6 +3,7 @@ package goja
 import (
 	"errors"
 	"math"
+	"sync"
 )
 
 type visitTracker struct {
@@ -66,6 +67,7 @@ type MemUsageContext struct {
 	memoryLimit                    uint64
 }
 
+var memContextMu sync.Mutex
 var latestMemUsageContext *MemUsageContext
 
 func NewMemUsageContext(
@@ -75,6 +77,8 @@ func NewMemUsageContext(
 	sampleRate float64,
 	nativeChecker NativeMemUsageChecker,
 ) *MemUsageContext {
+	memContextMu.Lock()
+	defer memContextMu.Unlock()
 	latestMemUsageContext = &MemUsageContext{
 		visitTracker:          visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})},
 		depthTracker:          &depthTracker{curDepth: 0, maxDepth: maxDepth},
@@ -96,6 +100,8 @@ func NewMemUsageContext(
 }
 
 func newMemUsageContextClone() *MemUsageContext {
+	memContextMu.Lock()
+	defer memContextMu.Unlock()
 	if latestMemUsageContext != nil {
 		return &MemUsageContext{
 			visitTracker:                   visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})},

--- a/mem_context.go
+++ b/mem_context.go
@@ -66,15 +66,16 @@ type MemUsageContext struct {
 	memoryLimit                    uint64
 }
 
+var latestMemUsageContext *MemUsageContext
+
 func NewMemUsageContext(
-	vm *Runtime,
 	maxDepth int,
 	memLimit uint64,
 	arrayLenThreshold, objPropsLenThreshold int,
 	sampleRate float64,
 	nativeChecker NativeMemUsageChecker,
 ) *MemUsageContext {
-	return &MemUsageContext{
+	latestMemUsageContext = &MemUsageContext{
 		visitTracker:          visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})},
 		depthTracker:          &depthTracker{curDepth: 0, maxDepth: maxDepth},
 		NativeMemUsageChecker: nativeChecker,
@@ -91,6 +92,22 @@ func NewMemUsageContext(
 			return computeSampleStep(totalItems, sampleRate)
 		},
 	}
+	return latestMemUsageContext
+}
+
+func newMemUsageContextClone() *MemUsageContext {
+	if latestMemUsageContext != nil {
+		return &MemUsageContext{
+			visitTracker:                   visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})},
+			depthTracker:                   &depthTracker{curDepth: 0, maxDepth: latestMemUsageContext.maxDepth},
+			NativeMemUsageChecker:          nil,
+			memoryLimit:                    latestMemUsageContext.memoryLimit,
+			ArrayLenExceedsThreshold:       latestMemUsageContext.ArrayLenExceedsThreshold,
+			ObjectPropsLenExceedsThreshold: latestMemUsageContext.ObjectPropsLenExceedsThreshold,
+			ComputeSampleStep:              latestMemUsageContext.ComputeSampleStep,
+		}
+	}
+	return nil
 }
 
 // MemUsageLimitExceeded ensures a limit function is defined and checks against the limit. If limit is breached

--- a/mem_context.go
+++ b/mem_context.go
@@ -67,7 +67,7 @@ type MemUsageContext struct {
 	memoryLimit                    uint64
 }
 
-var memContextMu sync.Mutex
+var memContextMu sync.RWMutex
 var latestMemUsageContext *MemUsageContext
 
 func NewMemUsageContext(
@@ -100,8 +100,8 @@ func NewMemUsageContext(
 }
 
 func newMemUsageContextClone() *MemUsageContext {
-	memContextMu.Lock()
-	defer memContextMu.Unlock()
+	memContextMu.RLock()
+	defer memContextMu.RUnlock()
 	if latestMemUsageContext != nil {
 		return &MemUsageContext{
 			visitTracker:                   visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})},

--- a/mem_context.go
+++ b/mem_context.go
@@ -67,7 +67,13 @@ type MemUsageContext struct {
 	memoryLimit                    uint64
 }
 
+// memContextMu is used to protect the latestMemUsageContext variable.
 var memContextMu sync.RWMutex
+
+// latestMemUsageContext is used to store the latest MemUsageContext instance created.
+// This is needed to allow arbitrary mem usage checks with the same exact configuration
+// as the latest mem usage context. This is an escape hatch since a new mem usage
+// context is usually only created from the client using goja.
 var latestMemUsageContext *MemUsageContext
 
 func NewMemUsageContext(

--- a/mem_context.go
+++ b/mem_context.go
@@ -106,7 +106,7 @@ func newMemUsageContextClone() *MemUsageContext {
 		return &MemUsageContext{
 			visitTracker:                   visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})},
 			depthTracker:                   &depthTracker{curDepth: 0, maxDepth: latestMemUsageContext.maxDepth},
-			NativeMemUsageChecker:          nil,
+			NativeMemUsageChecker:          latestMemUsageContext.NativeMemUsageChecker,
 			memoryLimit:                    latestMemUsageContext.memoryLimit,
 			ArrayLenExceedsThreshold:       latestMemUsageContext.ArrayLenExceedsThreshold,
 			ObjectPropsLenExceedsThreshold: latestMemUsageContext.ObjectPropsLenExceedsThreshold,

--- a/mem_context.go
+++ b/mem_context.go
@@ -146,7 +146,8 @@ func computeSampleStep(totalItems int, sampleRate float64) int {
 }
 
 var (
-	ErrMaxDepth = errors.New("reached max depth")
+	ErrMaxDepth         = errors.New("reached max depth")
+	ErrMemLimitExceeded = errors.New("execution memory limit exceeded")
 )
 
 type MemUsageReporter interface {

--- a/memory_test.go
+++ b/memory_test.go
@@ -414,7 +414,7 @@ func TestMemCheck(t *testing.T) {
 
 			vm.Set("checkMem", func(call FunctionCall) Value {
 				mem, err := vm.MemUsage(
-					NewMemUsageContext(vm, 100, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
+					NewMemUsageContext(100, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -485,7 +485,7 @@ func TestMemMaxDepth(t *testing.T) {
 			// All global variables are contained in the Runtime's globalObject field, which causes
 			// them to be one level deeper
 			_, err = vm.MemUsage(
-				NewMemUsageContext(vm, tc.expectedDepth, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
+				NewMemUsageContext(tc.expectedDepth, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 			)
 			if err != ErrMaxDepth {
 				t.Fatalf("expected mem check to hit depth limit error, but got nil %v", err)
@@ -493,7 +493,7 @@ func TestMemMaxDepth(t *testing.T) {
 
 			_, err = vm.MemUsage(
 				// need to add 2 to the expectedDepth since Object is lazy loaded it adds onto the expected depth
-				NewMemUsageContext(vm, tc.expectedDepth+2, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
+				NewMemUsageContext(tc.expectedDepth+2, memUsageLimit, arrLenThreshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 			)
 			if err != nil {
 				t.Fatalf("expected to NOT hit mem check hit depth limit error, but got %v", err)
@@ -607,7 +607,7 @@ func TestMemArraysWithLenThreshold(t *testing.T) {
 
 			vm.Set("checkMem", func(call FunctionCall) Value {
 				mem, err := vm.MemUsage(
-					NewMemUsageContext(vm, 100, tc.memLimit, tc.threshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
+					NewMemUsageContext(100, tc.memLimit, tc.threshold, objPropsLenThreshold, 0.1, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -698,7 +698,7 @@ func TestMemObjectsWithPropsLenThreshold(t *testing.T) {
 
 			vm.Set("checkMem", func(call FunctionCall) Value {
 				mem, err := vm.MemUsage(
-					NewMemUsageContext(vm, 100, tc.memLimit, arrLenThreshold, tc.threshold, 0.1, TestNativeMemUsageChecker{}),
+					NewMemUsageContext(100, tc.memLimit, arrLenThreshold, tc.threshold, 0.1, TestNativeMemUsageChecker{}),
 				)
 				if err != nil {
 					t.Fatal(err)

--- a/object.go
+++ b/object.go
@@ -548,7 +548,7 @@ func (o *baseObject) setOwnStr(name unistring.String, val Value, throw bool) boo
 			o.val.runtime.typeErrorResult(throw, "Cannot add property %s, object is not extensible", name)
 			return false
 		} else {
-			if o.val.runtime.shouldForceMemCheck {
+			if o.val != nil && o.val.runtime != nil && o.val.runtime.shouldForceMemCheck {
 				memCtx := newMemUsageContextClone()
 				if memCtx != nil {
 					memUsage, err := val.MemUsage(memCtx)

--- a/object.go
+++ b/object.go
@@ -556,7 +556,7 @@ func (o *baseObject) setOwnStr(name unistring.String, val Value, throw bool) boo
 						panic(err)
 					}
 					if memCtx.MemUsageLimitExceeded(memUsage) {
-						panic("memory limit exceeded")
+						panic(ErrMemLimitExceeded)
 					}
 				}
 			}

--- a/object.go
+++ b/object.go
@@ -548,6 +548,18 @@ func (o *baseObject) setOwnStr(name unistring.String, val Value, throw bool) boo
 			o.val.runtime.typeErrorResult(throw, "Cannot add property %s, object is not extensible", name)
 			return false
 		} else {
+			if o.val.runtime.shouldForceMemCheck {
+				memCtx := newMemUsageContextClone()
+				if memCtx != nil {
+					memUsage, err := val.MemUsage(memCtx)
+					if err != nil {
+						panic(err)
+					}
+					if memCtx.MemUsageLimitExceeded(memUsage) {
+						panic("memory limit exceeded")
+					}
+				}
+			}
 			o.values[name] = val
 			names := copyNamesIfNeeded(o.propNames, 1)
 			o.propNames = append(names, name)

--- a/object.go
+++ b/object.go
@@ -549,8 +549,7 @@ func (o *baseObject) setOwnStr(name unistring.String, val Value, throw bool) boo
 			return false
 		} else {
 			if o.val != nil && o.val.runtime != nil && o.val.runtime.shouldForceMemCheck {
-				memCtx := newMemUsageContextClone()
-				if memCtx != nil {
+				if memCtx := newMemUsageContextClone(); memCtx != nil {
 					memUsage, err := val.MemUsage(memCtx)
 					if err != nil {
 						panic(err)

--- a/object_dynamic_test.go
+++ b/object_dynamic_test.go
@@ -460,7 +460,7 @@ func TestBaseDynamicObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -503,7 +503,7 @@ func TestDynamicArrayMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_gomap_test.go
+++ b/object_gomap_test.go
@@ -331,7 +331,7 @@ func TestGoMapUnicode(t *testing.T) {
 
 func TestGoMapMemUsage(t *testing.T) {
 	vm := New()
-	vmCtx := NewMemUsageContext(vm, 100, 100, 100, 100, 0.1, nil)
+	vmCtx := NewMemUsageContext(100, 100, 100, 100, 0.1, nil)
 
 	nestedMap := map[string]interface{}{
 		"subTest1": valueInt(99),
@@ -503,7 +503,7 @@ func TestGoMapMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, tc.memLimit, 100, tc.estimateThreshold, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, tc.memLimit, 100, tc.estimateThreshold, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_goslice_test.go
+++ b/object_goslice_test.go
@@ -442,7 +442,7 @@ func TestGoSliceMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, tc.memLimit, tc.estimateThreshold, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, tc.memLimit, tc.estimateThreshold, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_test.go
+++ b/object_test.go
@@ -758,7 +758,7 @@ func TestBaseObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, tc.threshold, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, tc.memLimit, 100, tc.threshold, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -816,7 +816,7 @@ func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/object_test.go
+++ b/object_test.go
@@ -1,6 +1,7 @@
 package goja
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -826,6 +827,66 @@ func TestPrimitiveValueObjectMemUsage(t *testing.T) {
 			if total != tc.expectedMem {
 				t.Fatalf("Unexpected memory return. Actual: %v Expected: %v", total, tc.expectedMem)
 			}
+		})
+	}
+}
+
+func TestSetOwnStr(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		memLimit            uint64
+		expectedPanic       bool
+		shouldForceMemCheck bool
+	}{
+		{
+			name:                "should not panic when setting a value in an object",
+			memLimit:            1000,
+			expectedPanic:       false,
+			shouldForceMemCheck: false,
+		},
+		{
+			name:                "should panic when setting a value in an object over the mem limit and mem usage check is forced",
+			memLimit:            0,
+			expectedPanic:       true,
+			shouldForceMemCheck: true,
+		},
+		{
+			name:                "should not panic when setting a value in an object over the mem limit and mem usage check is not forced",
+			memLimit:            0,
+			expectedPanic:       false,
+			shouldForceMemCheck: false,
+		},
+		{
+			name:                "should not panic when setting a value in an object under the mem limit and mem usage check is forced",
+			memLimit:            1000,
+			expectedPanic:       false,
+			shouldForceMemCheck: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tc.expectedPanic && r == nil {
+					t.Error("The code is expected to panic, but it didn't")
+				}
+				if !tc.expectedPanic && r != nil {
+					t.Errorf("The code panicked, but it should not have: %v", r)
+				}
+			}()
+			v := &Object{
+				runtime: NewWithContext(context.Background(), tc.shouldForceMemCheck),
+			}
+			o := &baseObject{
+				val:        v,
+				extensible: true,
+			}
+			o.init()
+			v.self = o
+
+			// Creating a mem usage context so it populates the package variable
+			NewMemUsageContext(100, tc.memLimit, 100, 100, 0.5, nil)
+
+			o.setOwnStr("test", valueInt(123), false)
 		})
 	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -68,7 +68,7 @@ func TestProxyMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -116,7 +116,7 @@ func TestJSProxyHandlerMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/runtime.go
+++ b/runtime.go
@@ -1401,7 +1401,9 @@ func New() *Runtime {
 }
 
 // NewWithContext creates an instance of a Javascript runtime that can be used to run code. Multiple instances may be created and
-// used simultaneously, however it is not possible to pass JS values across runtimes.
+// used simultaneously, however it is not possible to pass JS values across runtimes. The 'shouldForceMemCheck' parameter is a
+// safety net to trigger mem usage check on hot paths where memory usage is expected to be high but we can't otherwise catch it
+// with the poller.
 func NewWithContext(ctx context.Context, shouldForceMemCheck bool) *Runtime {
 	r := &Runtime{ctx: ctx, shouldForceMemCheck: shouldForceMemCheck}
 	r.init()

--- a/runtime.go
+++ b/runtime.go
@@ -210,6 +210,8 @@ type Runtime struct {
 
 	tickMetricTrackingEnabled bool
 	tickMetrics               map[string]uint64
+
+	shouldForceMemCheck bool
 }
 
 func (self *Runtime) Ticks() uint64 {
@@ -1400,8 +1402,8 @@ func New() *Runtime {
 
 // NewWithContext creates an instance of a Javascript runtime that can be used to run code. Multiple instances may be created and
 // used simultaneously, however it is not possible to pass JS values across runtimes.
-func NewWithContext(ctx context.Context) *Runtime {
-	r := &Runtime{ctx: ctx}
+func NewWithContext(ctx context.Context, shouldForceMemCheck bool) *Runtime {
+	r := &Runtime{ctx: ctx, shouldForceMemCheck: shouldForceMemCheck}
 	r.init()
 	return r
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3182,7 +3182,7 @@ func TestRuntimeMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, tc.memLimit, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/string_ascii_test.go
+++ b/string_ascii_test.go
@@ -27,7 +27,7 @@ func TestStringAsciiMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/string_imported_test.go
+++ b/string_imported_test.go
@@ -27,7 +27,7 @@ func TestStringImportedMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/string_test.go
+++ b/string_test.go
@@ -166,8 +166,6 @@ func BenchmarkASCIIConcat(b *testing.B) {
 }
 
 func TestStringObjectMemUsage(t *testing.T) {
-	vm := New()
-
 	for _, tc := range []struct {
 		name        string
 		val         *stringObject
@@ -186,7 +184,7 @@ func TestStringObjectMemUsage(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mem, err := tc.val.MemUsage(NewMemUsageContext(vm, 100, 100, 100, 100, 0.1, nil))
+			mem, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != nil {
 				t.Fatalf("Unexpected error. Actual: %v Expected: nil", err)
 			}

--- a/string_unicode_test.go
+++ b/string_unicode_test.go
@@ -27,7 +27,7 @@ func TestStringUnicodeMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -386,7 +386,7 @@ func TestArrayBufferObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -471,7 +471,7 @@ func TestTypedArrayObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -538,7 +538,7 @@ func TestDataViewObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/value_test.go
+++ b/value_test.go
@@ -110,7 +110,7 @@ func TestValueMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -167,7 +167,7 @@ func TestValuePropertyMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -278,7 +278,7 @@ func TestObjectMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}

--- a/vm_test.go
+++ b/vm_test.go
@@ -425,7 +425,7 @@ func TestValueStackMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, tc.memLimit, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -485,7 +485,7 @@ func TestVMContextMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -547,7 +547,7 @@ func TestStashMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := tc.val.MemUsage(NewMemUsageContext(New(), 100, 100, 100, 100, 0.1, nil))
+			total, err := tc.val.MemUsage(NewMemUsageContext(100, 100, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}
@@ -601,7 +601,7 @@ func TestTmpValuesMemUsage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			total, err := valuesMemUsage(tc.val, NewMemUsageContext(New(), 100, tc.memLimit, 100, 100, 0.1, nil))
+			total, err := valuesMemUsage(tc.val, NewMemUsageContext(100, tc.memLimit, 100, 100, 0.1, nil))
 			if err != tc.errExpected {
 				t.Fatalf("Unexpected error. Actual: %v Expected: %v", err, tc.errExpected)
 			}


### PR DESCRIPTION
This PR attempts to add a forced mem check on paths that have been historically causing OOMs. The poller is unable to catch these OOMs so we attempt to force a mem check ad-hoc where we usually risk very high memory usage.

For what it's worth I tried a small benchmark with this change

```
BenchmarkPutStr-10                	99246348	        12.62 ns/op	       0 B/op	       0 allocs/op
BenchmarkPutStrWithMemCheck-10    	93969940	        12.82 ns/op	       0 B/op	       0 allocs/op
```