### PR TITLE
BAAS-35403 track object with largest memory in vm value stack

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -210,6 +210,11 @@ type Runtime struct {
 
 	tickMetricTrackingEnabled bool
 	tickMetrics               map[string]uint64
+
+	// context used for tracking object with largest memory in the value stack. Must be non-nil if shouldTrackMaxMemOnStack is true
+	stackMemUsageContext     *MemUsageContext
+	shouldTrackMaxMemOnStack bool
+	maxStackObjectMem        uint64
 }
 
 func (self *Runtime) Ticks() uint64 {
@@ -578,6 +583,10 @@ func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, err error) {
 	}
 
 	return memUsage, nil
+}
+
+func (r *Runtime) MaxStackObjectMemUsage() uint64 {
+	return r.maxStackObjectMem
 }
 
 func (r *Runtime) newError(typ *Object, format string, args ...interface{}) Value {
@@ -1399,9 +1408,11 @@ func New() *Runtime {
 }
 
 // NewWithContext creates an instance of a Javascript runtime that can be used to run code. Multiple instances may be created and
-// used simultaneously, however it is not possible to pass JS values across runtimes.
-func NewWithContext(ctx context.Context) *Runtime {
-	r := &Runtime{ctx: ctx}
+// used simultaneously, however it is not possible to pass JS values across runtimes. The 'shouldTrackMaxMemOnStack' parameter is a
+// safety net to track the maxmium memory of objects on the vm's goja.Value stack as there will always be a Function or Arguments
+// object with memory usage totalling all referenced objects within the function. This covers edge cases missed by the memory poller.
+func NewWithContext(ctx context.Context, shouldTrackMaxMemOnStack bool, stackMemUsageContext *MemUsageContext) *Runtime {
+	r := &Runtime{ctx: ctx, shouldTrackMaxMemOnStack: shouldTrackMaxMemOnStack, stackMemUsageContext: stackMemUsageContext}
 	r.init()
 	return r
 }

--- a/runtime.go
+++ b/runtime.go
@@ -585,6 +585,7 @@ func (r *Runtime) MemUsage(ctx *MemUsageContext) (memUsage uint64, err error) {
 	return memUsage, nil
 }
 
+// MaxStackObjectMemUsage returns the memory used by the largest object seen in the vm value stack
 func (r *Runtime) MaxStackObjectMemUsage() uint64 {
 	return r.maxStackObjectMem
 }
@@ -1409,7 +1410,7 @@ func New() *Runtime {
 
 // NewWithContext creates an instance of a Javascript runtime that can be used to run code. Multiple instances may be created and
 // used simultaneously, however it is not possible to pass JS values across runtimes. The 'shouldTrackMaxMemOnStack' parameter is a
-// safety net to track the maxmium memory of objects on the vm's goja.Value stack as there will always be a Function or Arguments
+// safety net to track the maximum memory of objects on the vm's goja.Value stack as there will always be a Function or Arguments
 // object with memory usage totalling all referenced objects within the function. This covers edge cases missed by the memory poller.
 func NewWithContext(ctx context.Context, shouldTrackMaxMemOnStack bool, stackMemUsageContext *MemUsageContext) *Runtime {
 	r := &Runtime{ctx: ctx, shouldTrackMaxMemOnStack: shouldTrackMaxMemOnStack, stackMemUsageContext: stackMemUsageContext}

--- a/vm.go
+++ b/vm.go
@@ -870,6 +870,8 @@ func (vm *vm) push(v Value) {
 		return
 	}
 
+	// Any error will be swallowed here, though this should never happen.
+	// If an error occurs, the poller will catch the error when the object is checked
 	valueMemUsage, _ := v.MemUsage(vm.r.stackMemUsageContext)
 	vm.r.maxStackObjectMem = uint64(math.Max(float64(vm.r.maxStackObjectMem), float64(valueMemUsage)))
 }

--- a/vm.go
+++ b/vm.go
@@ -862,13 +862,8 @@ func (vm *vm) push(v Value) {
 		return
 	}
 
-	baseObjectClass := v.baseObject(vm.r).Class()
-
-	// Function and Arguments objects appear to contain references to other objects on the stack.
-	// Checking just these two types will be an efficient, but still accurate, memory estimate over checking all objects
-	if baseObjectClass != "Function" && baseObjectClass != "Arguments" {
-		return
-	}
+	// clear the visitTracker so mem check is forced on paths that contain objects with updated mem usage
+	vm.r.stackMemUsageContext.visitTracker = visitTracker{objsVisited: make(map[objectImpl]struct{}), stashesVisited: make(map[*stash]struct{})}
 
 	// Any error will be swallowed here, though this should never happen.
 	// If an error occurs, the poller will catch the error when the object is checked

--- a/vm.go
+++ b/vm.go
@@ -855,6 +855,23 @@ func (vm *vm) push(v Value) {
 	vm.stack.expand(vm.sp)
 	vm.stack[vm.sp] = v
 	vm.sp++
+
+	shouldTrackMaxMemOnStack := (vm.r != nil && vm.r.shouldTrackMaxMemOnStack)
+
+	if !shouldTrackMaxMemOnStack || v == nil || !v.IsObject() {
+		return
+	}
+
+	baseObjectClass := v.baseObject(vm.r).Class()
+
+	// Function and Arguments objects appear to contain references to other objects on the stack.
+	// Checking just these two types will be an efficient, but still accurate, memory estimate over checking all objects
+	if baseObjectClass != "Function" && baseObjectClass != "Arguments" {
+		return
+	}
+
+	valueMemUsage, _ := v.MemUsage(vm.r.stackMemUsageContext)
+	vm.r.maxStackObjectMem = uint64(math.Max(float64(vm.r.maxStackObjectMem), float64(valueMemUsage)))
 }
 
 func (vm *vm) pop() Value {

--- a/vm_test.go
+++ b/vm_test.go
@@ -757,3 +757,139 @@ func TestTickTracking(t *testing.T) {
 		})
 	}
 }
+
+const (
+	maxDepthVmStackTracker             int     = 15000
+	memLimitVmStackTracker             uint64  = 350 * (2 << 20)
+	arrayLenThresholdVmStackTracker    int     = 1000
+	objPropsLenThresholdVmStackTracker int     = 200
+	sampleRateVmStackTracker           float64 = 0.2
+)
+
+func BenchmarkStackPushMemTracking(b *testing.B) {
+	benchmarks := []struct {
+		name                     string
+		shouldTrackMaxMemOnStack bool
+	}{
+		{
+			name:                     "with stack mem tracking",
+			shouldTrackMaxMemOnStack: true,
+		},
+		{
+			name:                     "without stack mem tracking",
+			shouldTrackMaxMemOnStack: false,
+		},
+	}
+
+	const SCRIPT = `
+	function f() {
+		const foo = {"hello": "world"};
+		const bar = [];
+		const foobar = [];
+		for (var i = 0; i < 400; i++) {
+			foo['prop_' + i] = g();
+			bar.push(foo);
+			foobar.push(bar);
+		}
+			return foobar;
+	}
+	function g() {
+		const foo2 = {"hello": "world"};
+		const bar2 = [];
+		const foobar2 = [];
+		for (var i = 0; i < 400; i++) {
+			foo2['prop_' + i] = foo2;
+			bar2.push(foo2);
+			foobar2.push(bar2);
+		}
+	}
+	f()
+	`
+	dummyVm := New() // used for creating a goja input value for benchmarks
+	prg := MustCompile("test.js", SCRIPT, false)
+	res, err := dummyVm.RunProgram(prg)
+	if err != nil {
+		b.Fatalf("unexpected error: %s", err.Error())
+	}
+	if res == UndefinedValue() {
+		b.Fatal("undexpected undefined value returned from input")
+	}
+
+	for _, bm := range benchmarks {
+		vmRuntime := New() // use a seperate vm for each of the two benchmarks
+		vmRuntime.stackMemUsageContext = NewMemUsageContext(
+			maxDepthVmStackTracker,
+			memLimitVmStackTracker,
+			arrayLenThresholdVmStackTracker,
+			objPropsLenThresholdVmStackTracker,
+			sampleRateVmStackTracker,
+			nil,
+		)
+		b.ResetTimer()
+		b.Run(bm.name, func(b *testing.B) {
+			vmRuntime.shouldTrackMaxMemOnStack = bm.shouldTrackMaxMemOnStack
+
+			for i := 0; i < b.N; i++ {
+				vmRuntime.vm.push(res)
+			}
+		})
+	}
+}
+
+func BenchmarkVmMemTracking(b *testing.B) {
+	benchmarks := []struct {
+		name                     string
+		shouldTrackMaxMemOnStack bool
+	}{
+		{
+			name:                     "with stack mem tracking",
+			shouldTrackMaxMemOnStack: true,
+		},
+		{
+			name:                     "without stack mem tracking",
+			shouldTrackMaxMemOnStack: false,
+		},
+	}
+
+	const SCRIPT = `
+	function f() {
+		const foo = {"hello": "world"};
+		const bar = [];
+		const foobar = [];
+		for (var i = 0; i < 100; i++) {
+			foo['prop_' + i] = foo;
+			bar.push(foo);
+			foobar.push(bar);
+		}
+			return foobar;
+	}
+	f()
+	`
+	prg := MustCompile("test.js", SCRIPT, false)
+
+	for _, bm := range benchmarks {
+		vmRuntime := New() // use a seperate vm for each of the two benchmarks
+		vmRuntime.stackMemUsageContext = NewMemUsageContext(
+			maxDepthVmStackTracker,
+			memLimitVmStackTracker,
+			arrayLenThresholdVmStackTracker,
+			objPropsLenThresholdVmStackTracker,
+			sampleRateVmStackTracker,
+			nil,
+		)
+		b.ResetTimer()
+		b.Run(bm.name, func(b *testing.B) {
+			vmRuntime.shouldTrackMaxMemOnStack = bm.shouldTrackMaxMemOnStack
+
+			for i := 0; i < b.N; i++ {
+				res, err := vmRuntime.RunProgram(prg)
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err.Error())
+				}
+				if res == UndefinedValue() {
+					b.Fatal("undexpected undefined value returned from input")
+				}
+			}
+		})
+	}
+}

--- a/vm_test.go
+++ b/vm_test.go
@@ -816,7 +816,7 @@ func BenchmarkStackPushMemTracking(b *testing.B) {
 	}
 
 	for _, bm := range benchmarks {
-		vmRuntime := New() // use a seperate vm for each of the two benchmarks
+		vmRuntime := New() // use a separate vm for each of the two benchmarks
 		vmRuntime.stackMemUsageContext = NewMemUsageContext(
 			maxDepthVmStackTracker,
 			memLimitVmStackTracker,
@@ -868,7 +868,7 @@ func BenchmarkVmMemTracking(b *testing.B) {
 	prg := MustCompile("test.js", SCRIPT, false)
 
 	for _, bm := range benchmarks {
-		vmRuntime := New() // use a seperate vm for each of the two benchmarks
+		vmRuntime := New() // use a separate vm for each of the two benchmarks
 		vmRuntime.stackMemUsageContext = NewMemUsageContext(
 			maxDepthVmStackTracker,
 			memLimitVmStackTracker,

--- a/vm_test.go
+++ b/vm_test.go
@@ -856,12 +856,12 @@ func BenchmarkVmMemTracking(b *testing.B) {
 		const foo = {"hello": "world"};
 		const bar = [];
 		const foobar = [];
-		for (var i = 0; i < 100; i++) {
-			foo['prop_' + i] = foo;
+		for (var i = 0; i < 5; i++) {
+			foo['prop_' + i] = JSON.stringify(foo);
 			bar.push(foo);
 			foobar.push(bar);
 		}
-			return foobar;
+			return JSON.stringify({"returnVal": foobar});
 	}
 	f()
 	`


### PR DESCRIPTION
This PR does the following things:

- Add a flag to the runtime so we can feature flag the memory tracking change below
- Track the object with the largest memory used on the goja value stack. Theoretically the Function objects should contain references to other objects we can check memory for. However the largest memory I see is from an Arguments object which might be from some sub function or call happening under the hood when the program finishes. Instead of skipping these types, we will just check member all types since I noticed some incorrect tracked sizes in the `BenchmarkVmMemTracking` benchmark

-  Added benchmarks to test both an entire program execution via the VM and test the vm stack push independently to isolate the mem tracking differences. The benchmarks have some varying results so pasting 5 runs of each below for some reference data. While the first benchmark shows that tracking memory this way does have some overhead. But the second benchmark shows that it's negligible with objects 10k+ bytes in size


```
go test -benchmem -run=^$ -bench ^BenchmarkStackPushMemTracking$ -count=5            
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkStackPushMemTracking/with_stack_mem_tracking-10                   74139             17696 ns/op             998 B/op          3 allocs/op
BenchmarkStackPushMemTracking/with_stack_mem_tracking-10                   74660             16418 ns/op            2322 B/op          3 allocs/op
BenchmarkStackPushMemTracking/with_stack_mem_tracking-10                   72896             17230 ns/op            3662 B/op          3 allocs/op
BenchmarkStackPushMemTracking/with_stack_mem_tracking-10                   72631             17569 ns/op            4916 B/op          3 allocs/op
BenchmarkStackPushMemTracking/with_stack_mem_tracking-10                   70515             16899 ns/op            6203 B/op          3 allocs/op
BenchmarkStackPushMemTracking/without_stack_mem_tracking-10              1000000              2890 ns/op            7987 B/op          0 allocs/op
BenchmarkStackPushMemTracking/without_stack_mem_tracking-10               169609              7321 ns/op           17213 B/op          0 allocs/op
BenchmarkStackPushMemTracking/without_stack_mem_tracking-10               198897              6969 ns/op           20239 B/op          0 allocs/op
BenchmarkStackPushMemTracking/without_stack_mem_tracking-10               203395              6893 ns/op           23612 B/op          0 allocs/op
BenchmarkStackPushMemTracking/without_stack_mem_tracking-10               146028              7590 ns/op           26343 B/op          0 allocs/op
```



```
go test -benchmem -run=^$ -bench ^BenchmarkVmMemTracking$ -count=5                   
goos: darwin
goarch: arm64
pkg: github.com/dop251/goja
BenchmarkVmMemTracking/with_stack_mem_tracking-10                   5256            229754 ns/op          323156 B/op       1293 allocs/op
BenchmarkVmMemTracking/with_stack_mem_tracking-10                   5337            236230 ns/op          323175 B/op       1294 allocs/op
BenchmarkVmMemTracking/with_stack_mem_tracking-10                   5148            233559 ns/op          323162 B/op       1293 allocs/op
BenchmarkVmMemTracking/with_stack_mem_tracking-10                   5247            222142 ns/op          323187 B/op       1294 allocs/op
BenchmarkVmMemTracking/with_stack_mem_tracking-10                   5116            246885 ns/op          323181 B/op       1294 allocs/op
BenchmarkVmMemTracking/without_stack_mem_tracking-10                5840            203693 ns/op          308787 B/op       1114 allocs/op
BenchmarkVmMemTracking/without_stack_mem_tracking-10                5737            200969 ns/op          308750 B/op       1114 allocs/op
BenchmarkVmMemTracking/without_stack_mem_tracking-10                5820            203425 ns/op          308786 B/op       1114 allocs/op
BenchmarkVmMemTracking/without_stack_mem_tracking-10                5662            226229 ns/op          308799 B/op       1114 allocs/op
BenchmarkVmMemTracking/without_stack_mem_tracking-10                5665            201886 ns/op          308787 B/op       1114 allocs/op
```